### PR TITLE
Feat: separate "templates" from `create-astro` example choices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@netlify/functions": "^1.0.0",
         "@playwright/test": "^1.21.0",
         "@types/node": "^16.11.6",
-        "astro": "^1.0.0-beta.10",
+        "astro": "^1.0.0-beta.18",
         "install": "^0.13.0",
         "npm": "^8.1.2"
       }
@@ -33,9 +33,9 @@
       }
     },
     "node_modules/@astrojs/compiler": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-0.14.1.tgz",
-      "integrity": "sha512-dYgb52JvZE8jyDg84JkdJ/dTxRgHVbC47ou6Ymok/nZDh9kvlU7TJtEDCLlGfpfZTGvnkFTHMrz1kdbqCbFVCw==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-0.14.2.tgz",
+      "integrity": "sha512-kLj3iWkzPNk9TXWDY7bqGXRQ0XZbpwJNulQ7WrJCdv2zre7TG0E51x5ab8tCsiiTRZ2xORHuIz+gH2qFotXrKw==",
       "dev": true,
       "dependencies": {
         "tsm": "^2.2.1",
@@ -75,9 +75,9 @@
       }
     },
     "node_modules/@astrojs/markdown-remark": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-0.9.0.tgz",
-      "integrity": "sha512-yagb3udzk+xCoGSfyzA7LBS7Q4P8swGQzA8XURFPaK1HfY9BKYasUvtaTYGA7G0r8KeDKAOVmwzYP74gxXGslg==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-0.9.2.tgz",
+      "integrity": "sha512-0yOV1ucOvDyA9Bg1Rs56Zfe8EGtPxBfMReUQTAW/1hLZgIu8WgTCHuTRRT/z7UkjJHX8TiT9XMsUtBOI20cYWQ==",
       "dev": true,
       "dependencies": {
         "@astrojs/prism": "^0.4.1",
@@ -86,7 +86,6 @@
         "mdast-util-mdx-expression": "^1.2.0",
         "mdast-util-mdx-jsx": "^1.2.0",
         "mdast-util-to-string": "^3.1.0",
-        "micromark-extension-mdx-expression": "^1.0.3",
         "micromark-extension-mdx-jsx": "^1.0.3",
         "prismjs": "^1.27.0",
         "rehype-raw": "^6.1.1",
@@ -1094,9 +1093,9 @@
       "dev": true
     },
     "node_modules/@proload/core": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@proload/core/-/core-0.2.2.tgz",
-      "integrity": "sha512-HYQEblYXIpW77kvGyW4penEl9D9e9MouPhTqVaDz9+QVFliYjsq18inTfnfTa81s3oraPVtTk60tqCWOf2fKGQ==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@proload/core/-/core-0.3.2.tgz",
+      "integrity": "sha512-4ga4HpS0ieVYWVMS+F62W++6SNACBu0lkw8snw3tEdH6AeqZu8i8262n3I81jWAWXVcg3sMfhb+kBexrfGrTUQ==",
       "dev": true,
       "dependencies": {
         "deepmerge": "^4.2.2",
@@ -1104,15 +1103,15 @@
       }
     },
     "node_modules/@proload/plugin-tsm": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@proload/plugin-tsm/-/plugin-tsm-0.1.1.tgz",
-      "integrity": "sha512-qfGegg6I3YBCZDjYR9xb41MTc2EfL0sQQmw49Z/yi9OstIpUa/67MBy4AuNhoyG9FuOXia9gPoeBk5pGnBOGtA==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@proload/plugin-tsm/-/plugin-tsm-0.2.1.tgz",
+      "integrity": "sha512-Ex1sL2BxU+g8MHdAdq9SZKz+pU34o8Zcl9PHWo2WaG9hrnlZme607PU6gnpoAYsDBpHX327+eu60wWUk+d/b+A==",
       "dev": true,
       "dependencies": {
         "tsm": "^2.1.4"
       },
       "peerDependencies": {
-        "@proload/core": "^0.2.1"
+        "@proload/core": "^0.3.2"
       }
     },
     "node_modules/@types/acorn": {
@@ -1292,19 +1291,6 @@
       "integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A==",
       "dev": true
     },
-    "node_modules/@web/parse5-utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@web/parse5-utils/-/parse5-utils-1.3.0.tgz",
-      "integrity": "sha512-Pgkx3ECc8EgXSlS5EyrgzSOoUbM6P8OKS471HLAyvOBcP1NCBn0to4RN/OaKASGq8qa3j+lPX9H14uA5AHEnQg==",
-      "dev": true,
-      "dependencies": {
-        "@types/parse5": "^6.0.1",
-        "parse5": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -1446,23 +1432,22 @@
       }
     },
     "node_modules/astro": {
-      "version": "1.0.0-beta.10",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-1.0.0-beta.10.tgz",
-      "integrity": "sha512-AgP5pUMpj8ZKrJyT89tRh8hubI7o9OxhjIzs6AA5UxqBECGrLGK4PM5mieNHtpGU3XsEw1uOXTZQkoEfC+LOoQ==",
+      "version": "1.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-1.0.0-beta.18.tgz",
+      "integrity": "sha512-ttrJDf20s3jd1SrHvv8vJ6tkjrhNylHGpsmDOuMy36EMk5fmoL5NOtXzoex7FevwMfmQ90+mOOYst2TNnOjScA==",
       "dev": true,
       "dependencies": {
-        "@astrojs/compiler": "^0.14.1",
+        "@astrojs/compiler": "^0.14.2",
         "@astrojs/language-server": "^0.13.4",
-        "@astrojs/markdown-remark": "^0.9.0",
+        "@astrojs/markdown-remark": "^0.9.2",
         "@astrojs/prism": "0.4.1",
         "@astrojs/webapi": "^0.11.1",
         "@babel/core": "^7.17.9",
         "@babel/generator": "^7.17.9",
         "@babel/parser": "^7.17.9",
         "@babel/traverse": "^7.17.9",
-        "@proload/core": "^0.2.2",
-        "@proload/plugin-tsm": "^0.1.1",
-        "@web/parse5-utils": "^1.3.0",
+        "@proload/core": "^0.3.2-next.4",
+        "@proload/plugin-tsm": "^0.2.1-next.0",
         "ast-types": "^0.14.2",
         "boxen": "^6.2.1",
         "ci-info": "^3.3.0",
@@ -1471,7 +1456,7 @@
         "diff": "^5.0.0",
         "eol": "^0.9.1",
         "es-module-lexer": "^0.10.5",
-        "esbuild": "^0.14.34",
+        "esbuild": "^0.14.38",
         "estree-walker": "^3.0.1",
         "execa": "^6.1.0",
         "fast-glob": "^3.2.11",
@@ -1485,31 +1470,29 @@
         "micromorph": "^0.1.2",
         "mime": "^3.0.0",
         "ora": "^6.1.0",
-        "parse5": "^6.0.1",
         "path-browserify": "^1.0.1",
         "path-to-regexp": "^6.2.0",
         "postcss": "^8.4.12",
         "postcss-load-config": "^3.1.4",
         "preferred-pm": "^3.0.3",
-        "prismjs": "^1.27.0",
+        "prismjs": "^1.28.0",
         "prompts": "^2.4.2",
         "recast": "^0.20.5",
         "rehype-slug": "^5.0.1",
         "resolve": "^1.22.0",
-        "rollup": "^2.70.1",
-        "semver": "^7.3.6",
+        "rollup": "^2.70.2",
+        "semver": "^7.3.7",
         "serialize-javascript": "^6.0.0",
         "shiki": "^0.10.1",
         "shorthash": "^0.0.2",
         "sirv": "^2.0.2",
         "slash": "^4.0.0",
         "sourcemap-codec": "^1.4.8",
-        "srcset-parse": "^1.1.0",
         "string-width": "^5.1.2",
         "strip-ansi": "^7.0.1",
         "supports-esm": "^1.0.0",
         "tsconfig-resolver": "^3.0.1",
-        "vite": "^2.9.1",
+        "vite": "^2.9.5",
         "yargs-parser": "^21.0.1",
         "zod": "^3.14.4"
       },
@@ -2486,9 +2469,9 @@
       "dev": true
     },
     "node_modules/esbuild": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.36.tgz",
-      "integrity": "sha512-HhFHPiRXGYOCRlrhpiVDYKcFJRdO0sBElZ668M4lh2ER0YgnkLxECuFe7uWCf23FrcLc59Pqr7dHkTqmRPDHmw==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.38.tgz",
+      "integrity": "sha512-12fzJ0fsm7gVZX1YQ1InkOE5f9Tl7cgf6JPYXRJtPIoE0zkWAbHdPHVPPaLi9tYAcEBqheGzqLn/3RdTOyBfcA==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -2498,32 +2481,32 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "esbuild-android-64": "0.14.36",
-        "esbuild-android-arm64": "0.14.36",
-        "esbuild-darwin-64": "0.14.36",
-        "esbuild-darwin-arm64": "0.14.36",
-        "esbuild-freebsd-64": "0.14.36",
-        "esbuild-freebsd-arm64": "0.14.36",
-        "esbuild-linux-32": "0.14.36",
-        "esbuild-linux-64": "0.14.36",
-        "esbuild-linux-arm": "0.14.36",
-        "esbuild-linux-arm64": "0.14.36",
-        "esbuild-linux-mips64le": "0.14.36",
-        "esbuild-linux-ppc64le": "0.14.36",
-        "esbuild-linux-riscv64": "0.14.36",
-        "esbuild-linux-s390x": "0.14.36",
-        "esbuild-netbsd-64": "0.14.36",
-        "esbuild-openbsd-64": "0.14.36",
-        "esbuild-sunos-64": "0.14.36",
-        "esbuild-windows-32": "0.14.36",
-        "esbuild-windows-64": "0.14.36",
-        "esbuild-windows-arm64": "0.14.36"
+        "esbuild-android-64": "0.14.38",
+        "esbuild-android-arm64": "0.14.38",
+        "esbuild-darwin-64": "0.14.38",
+        "esbuild-darwin-arm64": "0.14.38",
+        "esbuild-freebsd-64": "0.14.38",
+        "esbuild-freebsd-arm64": "0.14.38",
+        "esbuild-linux-32": "0.14.38",
+        "esbuild-linux-64": "0.14.38",
+        "esbuild-linux-arm": "0.14.38",
+        "esbuild-linux-arm64": "0.14.38",
+        "esbuild-linux-mips64le": "0.14.38",
+        "esbuild-linux-ppc64le": "0.14.38",
+        "esbuild-linux-riscv64": "0.14.38",
+        "esbuild-linux-s390x": "0.14.38",
+        "esbuild-netbsd-64": "0.14.38",
+        "esbuild-openbsd-64": "0.14.38",
+        "esbuild-sunos-64": "0.14.38",
+        "esbuild-windows-32": "0.14.38",
+        "esbuild-windows-64": "0.14.38",
+        "esbuild-windows-arm64": "0.14.38"
       }
     },
     "node_modules/esbuild-android-64": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.36.tgz",
-      "integrity": "sha512-jwpBhF1jmo0tVCYC/ORzVN+hyVcNZUWuozGcLHfod0RJCedTDTvR4nwlTXdx1gtncDqjk33itjO+27OZHbiavw==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.38.tgz",
+      "integrity": "sha512-aRFxR3scRKkbmNuGAK+Gee3+yFxkTJO/cx83Dkyzo4CnQl/2zVSurtG6+G86EQIZ+w+VYngVyK7P3HyTBKu3nw==",
       "cpu": [
         "x64"
       ],
@@ -2537,9 +2520,9 @@
       }
     },
     "node_modules/esbuild-android-arm64": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.36.tgz",
-      "integrity": "sha512-/hYkyFe7x7Yapmfv4X/tBmyKnggUmdQmlvZ8ZlBnV4+PjisrEhAvC3yWpURuD9XoB8Wa1d5dGkTsF53pIvpjsg==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.38.tgz",
+      "integrity": "sha512-L2NgQRWuHFI89IIZIlpAcINy9FvBk6xFVZ7xGdOwIm8VyhX1vNCEqUJO3DPSSy945Gzdg98cxtNt8Grv1CsyhA==",
       "cpu": [
         "arm64"
       ],
@@ -2553,9 +2536,9 @@
       }
     },
     "node_modules/esbuild-darwin-64": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.36.tgz",
-      "integrity": "sha512-kkl6qmV0dTpyIMKagluzYqlc1vO0ecgpviK/7jwPbRDEv5fejRTaBBEE2KxEQbTHcLhiiDbhG7d5UybZWo/1zQ==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.38.tgz",
+      "integrity": "sha512-5JJvgXkX87Pd1Og0u/NJuO7TSqAikAcQQ74gyJ87bqWRVeouky84ICoV4sN6VV53aTW+NE87qLdGY4QA2S7KNA==",
       "cpu": [
         "x64"
       ],
@@ -2569,9 +2552,9 @@
       }
     },
     "node_modules/esbuild-darwin-arm64": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.36.tgz",
-      "integrity": "sha512-q8fY4r2Sx6P0Pr3VUm//eFYKVk07C5MHcEinU1BjyFnuYz4IxR/03uBbDwluR6ILIHnZTE7AkTUWIdidRi1Jjw==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.38.tgz",
+      "integrity": "sha512-eqF+OejMI3mC5Dlo9Kdq/Ilbki9sQBw3QlHW3wjLmsLh+quNfHmGMp3Ly1eWm981iGBMdbtSS9+LRvR2T8B3eQ==",
       "cpu": [
         "arm64"
       ],
@@ -2585,9 +2568,9 @@
       }
     },
     "node_modules/esbuild-freebsd-64": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.36.tgz",
-      "integrity": "sha512-Hn8AYuxXXRptybPqoMkga4HRFE7/XmhtlQjXFHoAIhKUPPMeJH35GYEUWGbjteai9FLFvBAjEAlwEtSGxnqWww==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.38.tgz",
+      "integrity": "sha512-epnPbhZUt93xV5cgeY36ZxPXDsQeO55DppzsIgWM8vgiG/Rz+qYDLmh5ts3e+Ln1wA9dQ+nZmVHw+RjaW3I5Ig==",
       "cpu": [
         "x64"
       ],
@@ -2601,9 +2584,9 @@
       }
     },
     "node_modules/esbuild-freebsd-arm64": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.36.tgz",
-      "integrity": "sha512-S3C0attylLLRiCcHiJd036eDEMOY32+h8P+jJ3kTcfhJANNjP0TNBNL30TZmEdOSx/820HJFgRrqpNAvTbjnDA==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.38.tgz",
+      "integrity": "sha512-/9icXUYJWherhk+y5fjPI5yNUdFPtXHQlwP7/K/zg8t8lQdHVj20SqU9/udQmeUo5pDFHMYzcEFfJqgOVeKNNQ==",
       "cpu": [
         "arm64"
       ],
@@ -2617,9 +2600,9 @@
       }
     },
     "node_modules/esbuild-linux-32": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.36.tgz",
-      "integrity": "sha512-Eh9OkyTrEZn9WGO4xkI3OPPpUX7p/3QYvdG0lL4rfr73Ap2HAr6D9lP59VMF64Ex01LhHSXwIsFG/8AQjh6eNw==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.38.tgz",
+      "integrity": "sha512-QfgfeNHRFvr2XeHFzP8kOZVnal3QvST3A0cgq32ZrHjSMFTdgXhMhmWdKzRXP/PKcfv3e2OW9tT9PpcjNvaq6g==",
       "cpu": [
         "ia32"
       ],
@@ -2633,9 +2616,9 @@
       }
     },
     "node_modules/esbuild-linux-64": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.36.tgz",
-      "integrity": "sha512-vFVFS5ve7PuwlfgoWNyRccGDi2QTNkQo/2k5U5ttVD0jRFaMlc8UQee708fOZA6zTCDy5RWsT5MJw3sl2X6KDg==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.38.tgz",
+      "integrity": "sha512-uuZHNmqcs+Bj1qiW9k/HZU3FtIHmYiuxZ/6Aa+/KHb/pFKr7R3aVqvxlAudYI9Fw3St0VCPfv7QBpUITSmBR1Q==",
       "cpu": [
         "x64"
       ],
@@ -2649,9 +2632,9 @@
       }
     },
     "node_modules/esbuild-linux-arm": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.36.tgz",
-      "integrity": "sha512-NhgU4n+NCsYgt7Hy61PCquEz5aevI6VjQvxwBxtxrooXsxt5b2xtOUXYZe04JxqQo+XZk3d1gcr7pbV9MAQ/Lg==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.38.tgz",
+      "integrity": "sha512-FiFvQe8J3VKTDXG01JbvoVRXQ0x6UZwyrU4IaLBZeq39Bsbatd94Fuc3F1RGqPF5RbIWW7RvkVQjn79ejzysnA==",
       "cpu": [
         "arm"
       ],
@@ -2665,9 +2648,9 @@
       }
     },
     "node_modules/esbuild-linux-arm64": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.36.tgz",
-      "integrity": "sha512-24Vq1M7FdpSmaTYuu1w0Hdhiqkbto1I5Pjyi+4Cdw5fJKGlwQuw+hWynTcRI/cOZxBcBpP21gND7W27gHAiftw==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.38.tgz",
+      "integrity": "sha512-HlMGZTEsBrXrivr64eZ/EO0NQM8H8DuSENRok9d+Jtvq8hOLzrxfsAT9U94K3KOGk2XgCmkaI2KD8hX7F97lvA==",
       "cpu": [
         "arm64"
       ],
@@ -2681,9 +2664,9 @@
       }
     },
     "node_modules/esbuild-linux-mips64le": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.36.tgz",
-      "integrity": "sha512-hZUeTXvppJN+5rEz2EjsOFM9F1bZt7/d2FUM1lmQo//rXh1RTFYzhC0txn7WV0/jCC7SvrGRaRz0NMsRPf8SIA==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.38.tgz",
+      "integrity": "sha512-qd1dLf2v7QBiI5wwfil9j0HG/5YMFBAmMVmdeokbNAMbcg49p25t6IlJFXAeLzogv1AvgaXRXvgFNhScYEUXGQ==",
       "cpu": [
         "mips64el"
       ],
@@ -2697,9 +2680,9 @@
       }
     },
     "node_modules/esbuild-linux-ppc64le": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.36.tgz",
-      "integrity": "sha512-1Bg3QgzZjO+QtPhP9VeIBhAduHEc2kzU43MzBnMwpLSZ890azr4/A9Dganun8nsqD/1TBcqhId0z4mFDO8FAvg==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.38.tgz",
+      "integrity": "sha512-mnbEm7o69gTl60jSuK+nn+pRsRHGtDPfzhrqEUXyCl7CTOCLtWN2bhK8bgsdp6J/2NyS/wHBjs1x8aBWwP2X9Q==",
       "cpu": [
         "ppc64"
       ],
@@ -2713,9 +2696,9 @@
       }
     },
     "node_modules/esbuild-linux-riscv64": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.36.tgz",
-      "integrity": "sha512-dOE5pt3cOdqEhaufDRzNCHf5BSwxgygVak9UR7PH7KPVHwSTDAZHDoEjblxLqjJYpc5XaU9+gKJ9F8mp9r5I4A==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.38.tgz",
+      "integrity": "sha512-+p6YKYbuV72uikChRk14FSyNJZ4WfYkffj6Af0/Tw63/6TJX6TnIKE+6D3xtEc7DeDth1fjUOEqm+ApKFXbbVQ==",
       "cpu": [
         "riscv64"
       ],
@@ -2729,9 +2712,9 @@
       }
     },
     "node_modules/esbuild-linux-s390x": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.36.tgz",
-      "integrity": "sha512-g4FMdh//BBGTfVHjF6MO7Cz8gqRoDPzXWxRvWkJoGroKA18G9m0wddvPbEqcQf5Tbt2vSc1CIgag7cXwTmoTXg==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.38.tgz",
+      "integrity": "sha512-0zUsiDkGJiMHxBQ7JDU8jbaanUY975CdOW1YDrurjrM0vWHfjv9tLQsW9GSyEb/heSK1L5gaweRjzfUVBFoybQ==",
       "cpu": [
         "s390x"
       ],
@@ -2745,9 +2728,9 @@
       }
     },
     "node_modules/esbuild-netbsd-64": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.36.tgz",
-      "integrity": "sha512-UB2bVImxkWk4vjnP62ehFNZ73lQY1xcnL5ZNYF3x0AG+j8HgdkNF05v67YJdCIuUJpBuTyCK8LORCYo9onSW+A==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.38.tgz",
+      "integrity": "sha512-cljBAApVwkpnJZfnRVThpRBGzCi+a+V9Ofb1fVkKhtrPLDYlHLrSYGtmnoTVWDQdU516qYI8+wOgcGZ4XIZh0Q==",
       "cpu": [
         "x64"
       ],
@@ -2761,9 +2744,9 @@
       }
     },
     "node_modules/esbuild-openbsd-64": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.36.tgz",
-      "integrity": "sha512-NvGB2Chf8GxuleXRGk8e9zD3aSdRO5kLt9coTQbCg7WMGXeX471sBgh4kSg8pjx0yTXRt0MlrUDnjVYnetyivg==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.38.tgz",
+      "integrity": "sha512-CDswYr2PWPGEPpLDUO50mL3WO/07EMjnZDNKpmaxUPsrW+kVM3LoAqr/CE8UbzugpEiflYqJsGPLirThRB18IQ==",
       "cpu": [
         "x64"
       ],
@@ -2777,9 +2760,9 @@
       }
     },
     "node_modules/esbuild-sunos-64": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.36.tgz",
-      "integrity": "sha512-VkUZS5ftTSjhRjuRLp+v78auMO3PZBXu6xl4ajomGenEm2/rGuWlhFSjB7YbBNErOchj51Jb2OK8lKAo8qdmsQ==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.38.tgz",
+      "integrity": "sha512-2mfIoYW58gKcC3bck0j7lD3RZkqYA7MmujFYmSn9l6TiIcAMpuEvqksO+ntBgbLep/eyjpgdplF7b+4T9VJGOA==",
       "cpu": [
         "x64"
       ],
@@ -2793,9 +2776,9 @@
       }
     },
     "node_modules/esbuild-windows-32": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.36.tgz",
-      "integrity": "sha512-bIar+A6hdytJjZrDxfMBUSEHHLfx3ynoEZXx/39nxy86pX/w249WZm8Bm0dtOAByAf4Z6qV0LsnTIJHiIqbw0w==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.38.tgz",
+      "integrity": "sha512-L2BmEeFZATAvU+FJzJiRLFUP+d9RHN+QXpgaOrs2klshoAm1AE6Us4X6fS9k33Uy5SzScn2TpcgecbqJza1Hjw==",
       "cpu": [
         "ia32"
       ],
@@ -2809,9 +2792,9 @@
       }
     },
     "node_modules/esbuild-windows-64": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.36.tgz",
-      "integrity": "sha512-+p4MuRZekVChAeueT1Y9LGkxrT5x7YYJxYE8ZOTcEfeUUN43vktSn6hUNsvxzzATrSgq5QqRdllkVBxWZg7KqQ==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.38.tgz",
+      "integrity": "sha512-Khy4wVmebnzue8aeSXLC+6clo/hRYeNIm0DyikoEqX+3w3rcvrhzpoix0S+MF9vzh6JFskkIGD7Zx47ODJNyCw==",
       "cpu": [
         "x64"
       ],
@@ -2825,9 +2808,9 @@
       }
     },
     "node_modules/esbuild-windows-arm64": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.36.tgz",
-      "integrity": "sha512-fBB4WlDqV1m18EF/aheGYQkQZHfPHiHJSBYzXIo8yKehek+0BtBwo/4PNwKGJ5T0YK0oc8pBKjgwPbzSrPLb+Q==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.38.tgz",
+      "integrity": "sha512-k3FGCNmHBkqdJXuJszdWciAH77PukEyDsdIryEHn9cKLQFxzhT39dSumeTuggaQcXY57UlmLGIkklWZo2qzHpw==",
       "cpu": [
         "arm64"
       ],
@@ -3257,9 +3240,9 @@
       }
     },
     "node_modules/has-bigints": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5036,31 +5019,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/micromark-extension-mdx-expression": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-1.0.3.tgz",
-      "integrity": "sha512-TjYtjEMszWze51NJCZmhv7MEBcgYRgb3tJeMAJ+HQCAaZHHRBaDCccqQzGizR/H4ODefP44wRTgOn2vE5I6nZA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "dependencies": {
-        "micromark-factory-mdx-expression": "^1.0.0",
-        "micromark-factory-space": "^1.0.0",
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-events-to-acorn": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0",
-        "uvu": "^0.5.0"
-      }
-    },
     "node_modules/micromark-extension-mdx-jsx": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-1.0.3.tgz",
@@ -5354,9 +5312,9 @@
       ]
     },
     "node_modules/micromark-util-events-to-acorn": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-1.0.4.tgz",
-      "integrity": "sha512-dpo8ecREK5s/KMph7jJ46RLM6g7N21CMc9LAJQbDLdbQnTpijigkSJPTIfLXZ+h5wdXlcsQ+b6ufAE9v76AdgA==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-1.0.6.tgz",
+      "integrity": "sha512-+kUMe2kNGy4mljNVt+YmFfwomSIVqX3NI6ePrk6SIl/0GaR53a6eUIGmhV5DDUkbLPPNWgVFCS6ExOqb0WFgHQ==",
       "dev": true,
       "funding": [
         {
@@ -5370,18 +5328,13 @@
       ],
       "dependencies": {
         "@types/acorn": "^4.0.0",
-        "@types/estree": "^0.0.50",
+        "@types/estree": "^0.0.51",
         "estree-util-visit": "^1.0.0",
         "micromark-util-types": "^1.0.0",
         "uvu": "^0.5.0",
+        "vfile-location": "^4.0.0",
         "vfile-message": "^3.0.0"
       }
-    },
-    "node_modules/micromark-util-events-to-acorn/node_modules/@types/estree": {
-      "version": "0.0.50",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
-      "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
-      "dev": true
     },
     "node_modules/micromark-util-html-tag-name": {
       "version": "1.0.0",
@@ -8592,9 +8545,9 @@
       }
     },
     "node_modules/prismjs": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
-      "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.28.0.tgz",
+      "integrity": "sha512-8aaXdYvl1F7iC7Xm1spqSaY/OJBpYW3v+KJ+F17iYxvdc8sfjW194COK5wVhMZX45tGteiBQgdvD/nhxcRwylw==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -9037,9 +8990,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.70.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.1.tgz",
-      "integrity": "sha512-CRYsI5EuzLbXdxC6RnYhOuRdtz4bhejPMSWjsFLfVM/7w/85n2szZv6yExqUXsBdz5KT8eoubeyDUDjhLHEslA==",
+      "version": "2.70.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.2.tgz",
+      "integrity": "sha512-EitogNZnfku65I1DD5Mxe8JYRUCy0hkK5X84IlDtUs+O6JRMpRciXTzyCUuX11b5L5pvjH+OmFXiQ3XjabcXgg==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -9306,12 +9259,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
-    },
-    "node_modules/srcset-parse": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/srcset-parse/-/srcset-parse-1.1.0.tgz",
-      "integrity": "sha512-JWp4cG2eybkvKA1QUHGoNK6JDEYcOnSuhzNGjZuYUPqXreDl/VkkvP2sZW7Rmh+icuCttrR9ccb2WPIazyM/Cw==",
       "dev": true
     },
     "node_modules/stack-utils": {
@@ -9732,14 +9679,14 @@
       }
     },
     "node_modules/unbox-primitive": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
       "dev": true,
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "has-bigints": "^1.0.1",
-        "has-symbols": "^1.0.2",
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       },
       "funding": {
@@ -10023,9 +9970,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.4.tgz",
-      "integrity": "sha512-7pO6ruZMsyTpaPB7kGtW+yj15Ze5g+E4w4Ramk1sAJLIuI4uPd5sauqubmZNpq0Yc1vLVxoXRf2Uj+qWxk5aXw==",
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.6.tgz",
+      "integrity": "sha512-3IffdrByHW95Yjv0a13TQOQfJs7L5dVlSPuTt432XLbRMriWbThqJN2k/IS6kXn5WY4xBLhK9XoaWay1B8VzUw==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.14.27",
@@ -10404,9 +10351,9 @@
       }
     },
     "@astrojs/compiler": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-0.14.1.tgz",
-      "integrity": "sha512-dYgb52JvZE8jyDg84JkdJ/dTxRgHVbC47ou6Ymok/nZDh9kvlU7TJtEDCLlGfpfZTGvnkFTHMrz1kdbqCbFVCw==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-0.14.2.tgz",
+      "integrity": "sha512-kLj3iWkzPNk9TXWDY7bqGXRQ0XZbpwJNulQ7WrJCdv2zre7TG0E51x5ab8tCsiiTRZ2xORHuIz+gH2qFotXrKw==",
       "dev": true,
       "requires": {
         "tsm": "^2.2.1",
@@ -10442,9 +10389,9 @@
       }
     },
     "@astrojs/markdown-remark": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-0.9.0.tgz",
-      "integrity": "sha512-yagb3udzk+xCoGSfyzA7LBS7Q4P8swGQzA8XURFPaK1HfY9BKYasUvtaTYGA7G0r8KeDKAOVmwzYP74gxXGslg==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-0.9.2.tgz",
+      "integrity": "sha512-0yOV1ucOvDyA9Bg1Rs56Zfe8EGtPxBfMReUQTAW/1hLZgIu8WgTCHuTRRT/z7UkjJHX8TiT9XMsUtBOI20cYWQ==",
       "dev": true,
       "requires": {
         "@astrojs/prism": "^0.4.1",
@@ -10453,7 +10400,6 @@
         "mdast-util-mdx-expression": "^1.2.0",
         "mdast-util-mdx-jsx": "^1.2.0",
         "mdast-util-to-string": "^3.1.0",
-        "micromark-extension-mdx-expression": "^1.0.3",
         "micromark-extension-mdx-jsx": "^1.0.3",
         "prismjs": "^1.27.0",
         "rehype-raw": "^6.1.1",
@@ -11207,9 +11153,9 @@
       "dev": true
     },
     "@proload/core": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@proload/core/-/core-0.2.2.tgz",
-      "integrity": "sha512-HYQEblYXIpW77kvGyW4penEl9D9e9MouPhTqVaDz9+QVFliYjsq18inTfnfTa81s3oraPVtTk60tqCWOf2fKGQ==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@proload/core/-/core-0.3.2.tgz",
+      "integrity": "sha512-4ga4HpS0ieVYWVMS+F62W++6SNACBu0lkw8snw3tEdH6AeqZu8i8262n3I81jWAWXVcg3sMfhb+kBexrfGrTUQ==",
       "dev": true,
       "requires": {
         "deepmerge": "^4.2.2",
@@ -11217,9 +11163,9 @@
       }
     },
     "@proload/plugin-tsm": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@proload/plugin-tsm/-/plugin-tsm-0.1.1.tgz",
-      "integrity": "sha512-qfGegg6I3YBCZDjYR9xb41MTc2EfL0sQQmw49Z/yi9OstIpUa/67MBy4AuNhoyG9FuOXia9gPoeBk5pGnBOGtA==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@proload/plugin-tsm/-/plugin-tsm-0.2.1.tgz",
+      "integrity": "sha512-Ex1sL2BxU+g8MHdAdq9SZKz+pU34o8Zcl9PHWo2WaG9hrnlZme607PU6gnpoAYsDBpHX327+eu60wWUk+d/b+A==",
       "dev": true,
       "requires": {
         "tsm": "^2.1.4"
@@ -11404,16 +11350,6 @@
         }
       }
     },
-    "@web/parse5-utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@web/parse5-utils/-/parse5-utils-1.3.0.tgz",
-      "integrity": "sha512-Pgkx3ECc8EgXSlS5EyrgzSOoUbM6P8OKS471HLAyvOBcP1NCBn0to4RN/OaKASGq8qa3j+lPX9H14uA5AHEnQg==",
-      "dev": true,
-      "requires": {
-        "@types/parse5": "^6.0.1",
-        "parse5": "^6.0.1"
-      }
-    },
     "agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -11521,23 +11457,22 @@
       }
     },
     "astro": {
-      "version": "1.0.0-beta.10",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-1.0.0-beta.10.tgz",
-      "integrity": "sha512-AgP5pUMpj8ZKrJyT89tRh8hubI7o9OxhjIzs6AA5UxqBECGrLGK4PM5mieNHtpGU3XsEw1uOXTZQkoEfC+LOoQ==",
+      "version": "1.0.0-beta.18",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-1.0.0-beta.18.tgz",
+      "integrity": "sha512-ttrJDf20s3jd1SrHvv8vJ6tkjrhNylHGpsmDOuMy36EMk5fmoL5NOtXzoex7FevwMfmQ90+mOOYst2TNnOjScA==",
       "dev": true,
       "requires": {
-        "@astrojs/compiler": "^0.14.1",
+        "@astrojs/compiler": "^0.14.2",
         "@astrojs/language-server": "^0.13.4",
-        "@astrojs/markdown-remark": "^0.9.0",
+        "@astrojs/markdown-remark": "^0.9.2",
         "@astrojs/prism": "0.4.1",
         "@astrojs/webapi": "^0.11.1",
         "@babel/core": "^7.17.9",
         "@babel/generator": "^7.17.9",
         "@babel/parser": "^7.17.9",
         "@babel/traverse": "^7.17.9",
-        "@proload/core": "^0.2.2",
-        "@proload/plugin-tsm": "^0.1.1",
-        "@web/parse5-utils": "^1.3.0",
+        "@proload/core": "^0.3.2-next.4",
+        "@proload/plugin-tsm": "^0.2.1-next.0",
         "ast-types": "^0.14.2",
         "boxen": "^6.2.1",
         "ci-info": "^3.3.0",
@@ -11546,7 +11481,7 @@
         "diff": "^5.0.0",
         "eol": "^0.9.1",
         "es-module-lexer": "^0.10.5",
-        "esbuild": "^0.14.34",
+        "esbuild": "^0.14.38",
         "estree-walker": "^3.0.1",
         "execa": "^6.1.0",
         "fast-glob": "^3.2.11",
@@ -11560,31 +11495,29 @@
         "micromorph": "^0.1.2",
         "mime": "^3.0.0",
         "ora": "^6.1.0",
-        "parse5": "^6.0.1",
         "path-browserify": "^1.0.1",
         "path-to-regexp": "^6.2.0",
         "postcss": "^8.4.12",
         "postcss-load-config": "^3.1.4",
         "preferred-pm": "^3.0.3",
-        "prismjs": "^1.27.0",
+        "prismjs": "^1.28.0",
         "prompts": "^2.4.2",
         "recast": "^0.20.5",
         "rehype-slug": "^5.0.1",
         "resolve": "^1.22.0",
-        "rollup": "^2.70.1",
-        "semver": "^7.3.6",
+        "rollup": "^2.70.2",
+        "semver": "^7.3.7",
         "serialize-javascript": "^6.0.0",
         "shiki": "^0.10.1",
         "shorthash": "^0.0.2",
         "sirv": "^2.0.2",
         "slash": "^4.0.0",
         "sourcemap-codec": "^1.4.8",
-        "srcset-parse": "^1.1.0",
         "string-width": "^5.1.2",
         "strip-ansi": "^7.0.1",
         "supports-esm": "^1.0.0",
         "tsconfig-resolver": "^3.0.1",
-        "vite": "^2.9.1",
+        "vite": "^2.9.5",
         "yargs-parser": "^21.0.1",
         "zod": "^3.14.4"
       },
@@ -12283,170 +12216,170 @@
       "dev": true
     },
     "esbuild": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.36.tgz",
-      "integrity": "sha512-HhFHPiRXGYOCRlrhpiVDYKcFJRdO0sBElZ668M4lh2ER0YgnkLxECuFe7uWCf23FrcLc59Pqr7dHkTqmRPDHmw==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.38.tgz",
+      "integrity": "sha512-12fzJ0fsm7gVZX1YQ1InkOE5f9Tl7cgf6JPYXRJtPIoE0zkWAbHdPHVPPaLi9tYAcEBqheGzqLn/3RdTOyBfcA==",
       "dev": true,
       "requires": {
-        "esbuild-android-64": "0.14.36",
-        "esbuild-android-arm64": "0.14.36",
-        "esbuild-darwin-64": "0.14.36",
-        "esbuild-darwin-arm64": "0.14.36",
-        "esbuild-freebsd-64": "0.14.36",
-        "esbuild-freebsd-arm64": "0.14.36",
-        "esbuild-linux-32": "0.14.36",
-        "esbuild-linux-64": "0.14.36",
-        "esbuild-linux-arm": "0.14.36",
-        "esbuild-linux-arm64": "0.14.36",
-        "esbuild-linux-mips64le": "0.14.36",
-        "esbuild-linux-ppc64le": "0.14.36",
-        "esbuild-linux-riscv64": "0.14.36",
-        "esbuild-linux-s390x": "0.14.36",
-        "esbuild-netbsd-64": "0.14.36",
-        "esbuild-openbsd-64": "0.14.36",
-        "esbuild-sunos-64": "0.14.36",
-        "esbuild-windows-32": "0.14.36",
-        "esbuild-windows-64": "0.14.36",
-        "esbuild-windows-arm64": "0.14.36"
+        "esbuild-android-64": "0.14.38",
+        "esbuild-android-arm64": "0.14.38",
+        "esbuild-darwin-64": "0.14.38",
+        "esbuild-darwin-arm64": "0.14.38",
+        "esbuild-freebsd-64": "0.14.38",
+        "esbuild-freebsd-arm64": "0.14.38",
+        "esbuild-linux-32": "0.14.38",
+        "esbuild-linux-64": "0.14.38",
+        "esbuild-linux-arm": "0.14.38",
+        "esbuild-linux-arm64": "0.14.38",
+        "esbuild-linux-mips64le": "0.14.38",
+        "esbuild-linux-ppc64le": "0.14.38",
+        "esbuild-linux-riscv64": "0.14.38",
+        "esbuild-linux-s390x": "0.14.38",
+        "esbuild-netbsd-64": "0.14.38",
+        "esbuild-openbsd-64": "0.14.38",
+        "esbuild-sunos-64": "0.14.38",
+        "esbuild-windows-32": "0.14.38",
+        "esbuild-windows-64": "0.14.38",
+        "esbuild-windows-arm64": "0.14.38"
       }
     },
     "esbuild-android-64": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.36.tgz",
-      "integrity": "sha512-jwpBhF1jmo0tVCYC/ORzVN+hyVcNZUWuozGcLHfod0RJCedTDTvR4nwlTXdx1gtncDqjk33itjO+27OZHbiavw==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.38.tgz",
+      "integrity": "sha512-aRFxR3scRKkbmNuGAK+Gee3+yFxkTJO/cx83Dkyzo4CnQl/2zVSurtG6+G86EQIZ+w+VYngVyK7P3HyTBKu3nw==",
       "dev": true,
       "optional": true
     },
     "esbuild-android-arm64": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.36.tgz",
-      "integrity": "sha512-/hYkyFe7x7Yapmfv4X/tBmyKnggUmdQmlvZ8ZlBnV4+PjisrEhAvC3yWpURuD9XoB8Wa1d5dGkTsF53pIvpjsg==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.38.tgz",
+      "integrity": "sha512-L2NgQRWuHFI89IIZIlpAcINy9FvBk6xFVZ7xGdOwIm8VyhX1vNCEqUJO3DPSSy945Gzdg98cxtNt8Grv1CsyhA==",
       "dev": true,
       "optional": true
     },
     "esbuild-darwin-64": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.36.tgz",
-      "integrity": "sha512-kkl6qmV0dTpyIMKagluzYqlc1vO0ecgpviK/7jwPbRDEv5fejRTaBBEE2KxEQbTHcLhiiDbhG7d5UybZWo/1zQ==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.38.tgz",
+      "integrity": "sha512-5JJvgXkX87Pd1Og0u/NJuO7TSqAikAcQQ74gyJ87bqWRVeouky84ICoV4sN6VV53aTW+NE87qLdGY4QA2S7KNA==",
       "dev": true,
       "optional": true
     },
     "esbuild-darwin-arm64": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.36.tgz",
-      "integrity": "sha512-q8fY4r2Sx6P0Pr3VUm//eFYKVk07C5MHcEinU1BjyFnuYz4IxR/03uBbDwluR6ILIHnZTE7AkTUWIdidRi1Jjw==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.38.tgz",
+      "integrity": "sha512-eqF+OejMI3mC5Dlo9Kdq/Ilbki9sQBw3QlHW3wjLmsLh+quNfHmGMp3Ly1eWm981iGBMdbtSS9+LRvR2T8B3eQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-freebsd-64": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.36.tgz",
-      "integrity": "sha512-Hn8AYuxXXRptybPqoMkga4HRFE7/XmhtlQjXFHoAIhKUPPMeJH35GYEUWGbjteai9FLFvBAjEAlwEtSGxnqWww==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.38.tgz",
+      "integrity": "sha512-epnPbhZUt93xV5cgeY36ZxPXDsQeO55DppzsIgWM8vgiG/Rz+qYDLmh5ts3e+Ln1wA9dQ+nZmVHw+RjaW3I5Ig==",
       "dev": true,
       "optional": true
     },
     "esbuild-freebsd-arm64": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.36.tgz",
-      "integrity": "sha512-S3C0attylLLRiCcHiJd036eDEMOY32+h8P+jJ3kTcfhJANNjP0TNBNL30TZmEdOSx/820HJFgRrqpNAvTbjnDA==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.38.tgz",
+      "integrity": "sha512-/9icXUYJWherhk+y5fjPI5yNUdFPtXHQlwP7/K/zg8t8lQdHVj20SqU9/udQmeUo5pDFHMYzcEFfJqgOVeKNNQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-32": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.36.tgz",
-      "integrity": "sha512-Eh9OkyTrEZn9WGO4xkI3OPPpUX7p/3QYvdG0lL4rfr73Ap2HAr6D9lP59VMF64Ex01LhHSXwIsFG/8AQjh6eNw==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.38.tgz",
+      "integrity": "sha512-QfgfeNHRFvr2XeHFzP8kOZVnal3QvST3A0cgq32ZrHjSMFTdgXhMhmWdKzRXP/PKcfv3e2OW9tT9PpcjNvaq6g==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-64": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.36.tgz",
-      "integrity": "sha512-vFVFS5ve7PuwlfgoWNyRccGDi2QTNkQo/2k5U5ttVD0jRFaMlc8UQee708fOZA6zTCDy5RWsT5MJw3sl2X6KDg==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.38.tgz",
+      "integrity": "sha512-uuZHNmqcs+Bj1qiW9k/HZU3FtIHmYiuxZ/6Aa+/KHb/pFKr7R3aVqvxlAudYI9Fw3St0VCPfv7QBpUITSmBR1Q==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-arm": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.36.tgz",
-      "integrity": "sha512-NhgU4n+NCsYgt7Hy61PCquEz5aevI6VjQvxwBxtxrooXsxt5b2xtOUXYZe04JxqQo+XZk3d1gcr7pbV9MAQ/Lg==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.38.tgz",
+      "integrity": "sha512-FiFvQe8J3VKTDXG01JbvoVRXQ0x6UZwyrU4IaLBZeq39Bsbatd94Fuc3F1RGqPF5RbIWW7RvkVQjn79ejzysnA==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-arm64": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.36.tgz",
-      "integrity": "sha512-24Vq1M7FdpSmaTYuu1w0Hdhiqkbto1I5Pjyi+4Cdw5fJKGlwQuw+hWynTcRI/cOZxBcBpP21gND7W27gHAiftw==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.38.tgz",
+      "integrity": "sha512-HlMGZTEsBrXrivr64eZ/EO0NQM8H8DuSENRok9d+Jtvq8hOLzrxfsAT9U94K3KOGk2XgCmkaI2KD8hX7F97lvA==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-mips64le": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.36.tgz",
-      "integrity": "sha512-hZUeTXvppJN+5rEz2EjsOFM9F1bZt7/d2FUM1lmQo//rXh1RTFYzhC0txn7WV0/jCC7SvrGRaRz0NMsRPf8SIA==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.38.tgz",
+      "integrity": "sha512-qd1dLf2v7QBiI5wwfil9j0HG/5YMFBAmMVmdeokbNAMbcg49p25t6IlJFXAeLzogv1AvgaXRXvgFNhScYEUXGQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-ppc64le": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.36.tgz",
-      "integrity": "sha512-1Bg3QgzZjO+QtPhP9VeIBhAduHEc2kzU43MzBnMwpLSZ890azr4/A9Dganun8nsqD/1TBcqhId0z4mFDO8FAvg==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.38.tgz",
+      "integrity": "sha512-mnbEm7o69gTl60jSuK+nn+pRsRHGtDPfzhrqEUXyCl7CTOCLtWN2bhK8bgsdp6J/2NyS/wHBjs1x8aBWwP2X9Q==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-riscv64": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.36.tgz",
-      "integrity": "sha512-dOE5pt3cOdqEhaufDRzNCHf5BSwxgygVak9UR7PH7KPVHwSTDAZHDoEjblxLqjJYpc5XaU9+gKJ9F8mp9r5I4A==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.38.tgz",
+      "integrity": "sha512-+p6YKYbuV72uikChRk14FSyNJZ4WfYkffj6Af0/Tw63/6TJX6TnIKE+6D3xtEc7DeDth1fjUOEqm+ApKFXbbVQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-s390x": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.36.tgz",
-      "integrity": "sha512-g4FMdh//BBGTfVHjF6MO7Cz8gqRoDPzXWxRvWkJoGroKA18G9m0wddvPbEqcQf5Tbt2vSc1CIgag7cXwTmoTXg==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.38.tgz",
+      "integrity": "sha512-0zUsiDkGJiMHxBQ7JDU8jbaanUY975CdOW1YDrurjrM0vWHfjv9tLQsW9GSyEb/heSK1L5gaweRjzfUVBFoybQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-netbsd-64": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.36.tgz",
-      "integrity": "sha512-UB2bVImxkWk4vjnP62ehFNZ73lQY1xcnL5ZNYF3x0AG+j8HgdkNF05v67YJdCIuUJpBuTyCK8LORCYo9onSW+A==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.38.tgz",
+      "integrity": "sha512-cljBAApVwkpnJZfnRVThpRBGzCi+a+V9Ofb1fVkKhtrPLDYlHLrSYGtmnoTVWDQdU516qYI8+wOgcGZ4XIZh0Q==",
       "dev": true,
       "optional": true
     },
     "esbuild-openbsd-64": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.36.tgz",
-      "integrity": "sha512-NvGB2Chf8GxuleXRGk8e9zD3aSdRO5kLt9coTQbCg7WMGXeX471sBgh4kSg8pjx0yTXRt0MlrUDnjVYnetyivg==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.38.tgz",
+      "integrity": "sha512-CDswYr2PWPGEPpLDUO50mL3WO/07EMjnZDNKpmaxUPsrW+kVM3LoAqr/CE8UbzugpEiflYqJsGPLirThRB18IQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-sunos-64": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.36.tgz",
-      "integrity": "sha512-VkUZS5ftTSjhRjuRLp+v78auMO3PZBXu6xl4ajomGenEm2/rGuWlhFSjB7YbBNErOchj51Jb2OK8lKAo8qdmsQ==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.38.tgz",
+      "integrity": "sha512-2mfIoYW58gKcC3bck0j7lD3RZkqYA7MmujFYmSn9l6TiIcAMpuEvqksO+ntBgbLep/eyjpgdplF7b+4T9VJGOA==",
       "dev": true,
       "optional": true
     },
     "esbuild-windows-32": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.36.tgz",
-      "integrity": "sha512-bIar+A6hdytJjZrDxfMBUSEHHLfx3ynoEZXx/39nxy86pX/w249WZm8Bm0dtOAByAf4Z6qV0LsnTIJHiIqbw0w==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.38.tgz",
+      "integrity": "sha512-L2BmEeFZATAvU+FJzJiRLFUP+d9RHN+QXpgaOrs2klshoAm1AE6Us4X6fS9k33Uy5SzScn2TpcgecbqJza1Hjw==",
       "dev": true,
       "optional": true
     },
     "esbuild-windows-64": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.36.tgz",
-      "integrity": "sha512-+p4MuRZekVChAeueT1Y9LGkxrT5x7YYJxYE8ZOTcEfeUUN43vktSn6hUNsvxzzATrSgq5QqRdllkVBxWZg7KqQ==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.38.tgz",
+      "integrity": "sha512-Khy4wVmebnzue8aeSXLC+6clo/hRYeNIm0DyikoEqX+3w3rcvrhzpoix0S+MF9vzh6JFskkIGD7Zx47ODJNyCw==",
       "dev": true,
       "optional": true
     },
     "esbuild-windows-arm64": {
-      "version": "0.14.36",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.36.tgz",
-      "integrity": "sha512-fBB4WlDqV1m18EF/aheGYQkQZHfPHiHJSBYzXIo8yKehek+0BtBwo/4PNwKGJ5T0YK0oc8pBKjgwPbzSrPLb+Q==",
+      "version": "0.14.38",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.38.tgz",
+      "integrity": "sha512-k3FGCNmHBkqdJXuJszdWciAH77PukEyDsdIryEHn9cKLQFxzhT39dSumeTuggaQcXY57UlmLGIkklWZo2qzHpw==",
       "dev": true,
       "optional": true
     },
@@ -12756,9 +12689,9 @@
       }
     },
     "has-bigints": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
       "dev": true
     },
     "has-flag": {
@@ -14018,21 +13951,6 @@
         "uvu": "^0.5.0"
       }
     },
-    "micromark-extension-mdx-expression": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-1.0.3.tgz",
-      "integrity": "sha512-TjYtjEMszWze51NJCZmhv7MEBcgYRgb3tJeMAJ+HQCAaZHHRBaDCccqQzGizR/H4ODefP44wRTgOn2vE5I6nZA==",
-      "dev": true,
-      "requires": {
-        "micromark-factory-mdx-expression": "^1.0.0",
-        "micromark-factory-space": "^1.0.0",
-        "micromark-util-character": "^1.0.0",
-        "micromark-util-events-to-acorn": "^1.0.0",
-        "micromark-util-symbol": "^1.0.0",
-        "micromark-util-types": "^1.0.0",
-        "uvu": "^0.5.0"
-      }
-    },
     "micromark-extension-mdx-jsx": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-1.0.3.tgz",
@@ -14192,25 +14110,18 @@
       "dev": true
     },
     "micromark-util-events-to-acorn": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-1.0.4.tgz",
-      "integrity": "sha512-dpo8ecREK5s/KMph7jJ46RLM6g7N21CMc9LAJQbDLdbQnTpijigkSJPTIfLXZ+h5wdXlcsQ+b6ufAE9v76AdgA==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-1.0.6.tgz",
+      "integrity": "sha512-+kUMe2kNGy4mljNVt+YmFfwomSIVqX3NI6ePrk6SIl/0GaR53a6eUIGmhV5DDUkbLPPNWgVFCS6ExOqb0WFgHQ==",
       "dev": true,
       "requires": {
         "@types/acorn": "^4.0.0",
-        "@types/estree": "^0.0.50",
+        "@types/estree": "^0.0.51",
         "estree-util-visit": "^1.0.0",
         "micromark-util-types": "^1.0.0",
         "uvu": "^0.5.0",
+        "vfile-location": "^4.0.0",
         "vfile-message": "^3.0.0"
-      },
-      "dependencies": {
-        "@types/estree": {
-          "version": "0.0.50",
-          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
-          "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
-          "dev": true
-        }
       }
     },
     "micromark-util-html-tag-name": {
@@ -16432,9 +16343,9 @@
       }
     },
     "prismjs": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
-      "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.28.0.tgz",
+      "integrity": "sha512-8aaXdYvl1F7iC7Xm1spqSaY/OJBpYW3v+KJ+F17iYxvdc8sfjW194COK5wVhMZX45tGteiBQgdvD/nhxcRwylw==",
       "dev": true
     },
     "progress": {
@@ -16763,9 +16674,9 @@
       }
     },
     "rollup": {
-      "version": "2.70.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.1.tgz",
-      "integrity": "sha512-CRYsI5EuzLbXdxC6RnYhOuRdtz4bhejPMSWjsFLfVM/7w/85n2szZv6yExqUXsBdz5KT8eoubeyDUDjhLHEslA==",
+      "version": "2.70.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.2.tgz",
+      "integrity": "sha512-EitogNZnfku65I1DD5Mxe8JYRUCy0hkK5X84IlDtUs+O6JRMpRciXTzyCUuX11b5L5pvjH+OmFXiQ3XjabcXgg==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
@@ -16963,12 +16874,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
-    },
-    "srcset-parse": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/srcset-parse/-/srcset-parse-1.1.0.tgz",
-      "integrity": "sha512-JWp4cG2eybkvKA1QUHGoNK6JDEYcOnSuhzNGjZuYUPqXreDl/VkkvP2sZW7Rmh+icuCttrR9ccb2WPIazyM/Cw==",
       "dev": true
     },
     "stack-utils": {
@@ -17264,14 +17169,14 @@
       "dev": true
     },
     "unbox-primitive": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
       "dev": true,
       "requires": {
-        "function-bind": "^1.1.1",
-        "has-bigints": "^1.0.1",
-        "has-symbols": "^1.0.2",
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
     },
@@ -17476,9 +17381,9 @@
       }
     },
     "vite": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.4.tgz",
-      "integrity": "sha512-7pO6ruZMsyTpaPB7kGtW+yj15Ze5g+E4w4Ramk1sAJLIuI4uPd5sauqubmZNpq0Yc1vLVxoXRf2Uj+qWxk5aXw==",
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.6.tgz",
+      "integrity": "sha512-3IffdrByHW95Yjv0a13TQOQfJs7L5dVlSPuTt432XLbRMriWbThqJN2k/IS6kXn5WY4xBLhK9XoaWay1B8VzUw==",
       "dev": true,
       "requires": {
         "esbuild": "^0.14.27",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@netlify/functions": "^1.0.0",
     "@playwright/test": "^1.21.0",
     "@types/node": "^16.11.6",
-    "astro": "^1.0.0-beta.10",
+    "astro": "^1.0.0-beta.18",
     "install": "^0.13.0",
     "npm": "^8.1.2"
   },

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,4 +1,5 @@
 ---
+import { TOP_SECTION } from '../utils/index'
 import Card from '../components/Card.astro';
 const { examples: groups } = Astro.props;
 const { pathname } = Astro.request.url;
@@ -73,7 +74,7 @@ const { pathname } = Astro.request.url;
 			{groups.map(([category, examples], i) => {
 				return (
 					<li>
-						<h2>{category}</h2>
+						{category !== TOP_SECTION ? <h2>{category}</h2> : null}
 						<ul class="cards" style={`--base: ${i + 1};`}>
 							{examples.map((example, j) => <li><Card {...example} index={j + 1} /></li>)}
 						</ul>

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,7 +6,7 @@ const TITLES = new Map([
   ["with-markdown-plugins", "Markdown (Remark Plugins)"],
   ["framework-multiple", "Kitchen Sink (Multiple Frameworks)"],
   ["basics", "Just the Basics"],
-  ["minimal", "Completely empty"],
+  ["minimal", "Completely Empty"],
 ]);
 // this heading is hidden from the page
 export const TOP_SECTION = "TOP_SECTION";
@@ -114,7 +114,7 @@ export async function getExamples(ref = "latest") {
     }`;
   }
   const examples = await fetch(
-    `https://api.github.com/repos/withastro/astro/contents/examples?ref=${ref}`,
+    `https://api.github.com/repos/withastro/astro/contents/examples`,
     {
       headers,
     }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -114,7 +114,7 @@ export async function getExamples(ref = "latest") {
     }`;
   }
   const examples = await fetch(
-    `https://api.github.com/repos/withastro/astro/contents/examples`,
+    `https://api.github.com/repos/withastro/astro/contents/examples?ref=${ref}`,
     {
       headers,
     }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,10 +5,22 @@ const TITLES = new Map([
   ["blog-multiple-authors", "Blog (Complex)"],
   ["with-markdown-plugins", "Markdown (Remark Plugins)"],
   ["framework-multiple", "Kitchen Sink (Multiple Frameworks)"],
+  ["basics", "Just the Basics"],
+  ["minimal", "Completely empty"],
 ]);
-const FEATURED_TEMPLATES = new Set(["starter", "minimal"]);
+// this heading is hidden from the page
+export const TOP_SECTION = "TOP_SECTION";
+const TOP_SECTION_ORDER = ["basics", "blog", "docs", "portfolio", "minimal"];
+
 const FEATURED_INTEGRATIONS = new Set(["tailwindcss"]);
-const FRAMEWORK_ORDER = ["react", "preact", "vue", "svelte", "lit", "solid"].map(name => `framework-${name}`);
+const FRAMEWORK_ORDER = [
+  "react",
+  "preact",
+  "vue",
+  "svelte",
+  "lit",
+  "solid",
+].map((name) => `framework-${name}`);
 
 interface ExampleData {
   name: string;
@@ -27,12 +39,14 @@ export interface Example {
 }
 
 function toExample({ name }: ExampleData, ref: string): Example {
-  const suffix = ref === 'main' ? '@next' : '';
+  const suffix = ref === "main" ? "@next" : "";
   let title: string;
   if (TITLES.has(name)) {
     title = TITLES.get(name);
   } else {
-    title = toTitle(name.replace(/^(with|framework)/, "").replace(/-/g, " ")).trim();
+    title = toTitle(
+      name.replace(/^(with|framework)/, "").replace(/-/g, " ")
+    ).trim();
   }
   return {
     name,
@@ -49,16 +63,20 @@ function groupExamplesByCategory(
   ref: string
 ): [string, Example[]][] {
   const groups: Record<string, Example[]> = {
-    Templates: [],
+    [TOP_SECTION]: [],
     Frameworks: [],
     Integrations: [],
+    Templates: [],
   };
   for (const example of examples) {
     if (example.size !== 0) continue;
     const data = toExample(example, ref);
     switch (true) {
+      case TOP_SECTION_ORDER.includes(example.name):
+        groups[TOP_SECTION].push(data);
+        break;
       case example.name.startsWith("with-"):
-        if (FEATURED_INTEGRATIONS.has(example.name.replace('with-', ''))) {
+        if (FEATURED_INTEGRATIONS.has(example.name.replace("with-", ""))) {
           groups["Integrations"].splice(0, 0, data);
         } else {
           groups["Integrations"].push(data);
@@ -68,18 +86,50 @@ function groupExamplesByCategory(
         groups["Frameworks"].push(data);
         break;
       default: {
-        if (FEATURED_TEMPLATES.has(example.name)) {
-          groups["Templates"].splice(0, 0, data);
-        } else {
-          groups["Templates"].push(data);
-        }
+        groups["Templates"].push(data);
         break;
       }
     }
   }
-  groups["Frameworks"] = groups["Frameworks"].sort((a, b) => {
-    let aIndex = FRAMEWORK_ORDER.indexOf(a.name);
-    let bIndex = FRAMEWORK_ORDER.indexOf(b.name);
+  groups[TOP_SECTION] = groups[TOP_SECTION].sort(
+    sortExamplesByOrder(TOP_SECTION_ORDER)
+  );
+  groups["Frameworks"] = groups["Frameworks"].sort(
+    sortExamplesByOrder(FRAMEWORK_ORDER)
+  );
+  return Object.entries(groups);
+}
+
+export async function getExamples(ref = "latest") {
+  const headers = {
+    Accept: "application/vnd.github.v3+json",
+  };
+  if (typeof import.meta.env.PUBLIC_VITE_GITHUB_TOKEN === "undefined") {
+    console.warn(
+      `PUBLIC_VITE_GITHUB_TOKEN is undefined. You may run into rate-limiting issues.`
+    );
+  } else {
+    headers["Authorization"] = `token ${
+      import.meta.env.PUBLIC_VITE_GITHUB_TOKEN
+    }`;
+  }
+  const examples = await fetch(
+    `https://api.github.com/repos/withastro/astro/contents/examples?ref=${ref}`,
+    {
+      headers,
+    }
+  ).then((res) => res.json());
+  if (!Array.isArray(examples)) {
+    console.log(examples);
+    throw new Error(`GITHUB_TOKEN appears to be misconfigured`);
+  }
+  return groupExamplesByCategory(examples, ref);
+}
+
+function sortExamplesByOrder(order: string[]) {
+  return (a: Example, b: Example) => {
+    let aIndex = order.indexOf(a.name);
+    let bIndex = order.indexOf(b.name);
     if (aIndex === -1) {
       aIndex = Infinity;
     }
@@ -88,28 +138,5 @@ function groupExamplesByCategory(
     }
     if (aIndex > bIndex) return 1;
     if (aIndex < bIndex) return -1;
-  })
-  return Object.entries(groups);
-}
-
-export async function getExamples(ref = "latest") {
-  const headers = {
-    Accept: "application/vnd.github.v3+json",
-  }
-  if (typeof import.meta.env.PUBLIC_VITE_GITHUB_TOKEN === 'undefined') {
-    console.warn(`PUBLIC_VITE_GITHUB_TOKEN is undefined. You may run into rate-limiting issues.`);
-  } else {
-    headers['Authorization'] = `token ${import.meta.env.PUBLIC_VITE_GITHUB_TOKEN}`;
-  }
-  const examples = await fetch(
-    `https://api.github.com/repos/withastro/astro/contents/examples?ref=${ref}`,
-    {
-      headers
-    }
-  ).then((res) => res.json());
-  if (!Array.isArray(examples)) {
-    console.log(examples);
-    throw new Error(`GITHUB_TOKEN appears to be misconfigured`);
-  }
-  return groupExamplesByCategory(examples, ref);
+  };
 }


### PR DESCRIPTION
**What changed?**
- split out our 5 `create-astro` templates to a top section without a heading
- push remaining templates (blog complex, component, etc) to a separate "templates" section at the bottom of the list

☝️ This should push users to view our core templates first, frameworks and integrations second, and more "speciality" templates like blog (complex) last

<img width="455" alt="image" src="https://user-images.githubusercontent.com/51384119/165625583-20f18ada-bf61-47f3-b9a4-8725f23feb4f.png">