### PR TITLE
Fix `<Starfield>` so it covers the full header

### DIFF
--- a/src/components/Starfield.astro
+++ b/src/components/Starfield.astro
@@ -9,7 +9,7 @@ const { subtle, noGradient } = Astro.props as Props;
 
 <div class:list={[
     "pointer-events-none",
-    "absolute inset-0 -z-50 border-t-[3.5rem] border-slate-900",
+    "absolute inset-0 -z-50 border-slate-900",
     subtle && "bg-[length:100%_175%]",
     noGradient ? 'bg-slate-900' : 'bg-gradient-to-b bg-no-repeat bg-purple-800 from-slate-900 to-purple-800'
 ]}>


### PR DESCRIPTION
The `<Starfield>` component had a top border left over from its use on astro.build — this PR removes that to make sure we get stars across the full header ✨ 