### PR TITLE
Even friendlier astro.new

### DIFF
--- a/src/components/Outlinks.astro
+++ b/src/components/Outlinks.astro
@@ -1,0 +1,24 @@
+<li>
+  <article
+    class="flex flex-col justify-evenly gap-8 text-center h-full p-8 text-neutral-50 bg-gradient-to-b from-neutral-900 to-primary-900 rounded-lg shadow-inner shadow-black"
+  >
+    <p>
+      Looking to learn more?<br />
+      <a
+        class="text-secondary-400 font-bold hover:underline"
+        href="https://docs.astro.build"
+      >
+        Check out the Astro docs
+      </a>
+    </p>
+    <p>
+      Have questions?<br />
+      <a
+        class="text-secondary-400 font-bold hover:underline"
+        href="https://astro.build/chat"
+      >
+        Join us on Discord
+      </a>
+    </p>
+  </article>
+</li>

--- a/src/components/PageTitle.astro
+++ b/src/components/PageTitle.astro
@@ -8,11 +8,11 @@ export interface Props {
 const { as: Component = 'div', ...props } = Astro.props as Props
 ---
 
-<Component class="relative py-12 md:py-16 lg:py-20">
+<Component class="relative py-12 lg:py-20">
     <Starfield subtle />
-    <section class="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8 flex flex-wrap gap-5 lg:gap-16 justify-between items-center">
+    <section class="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8 flex flex-wrap gap-5 sm:gap-10 lg:gap-16 justify-between items-center">
         <h1
-            class="text-3xl font-extrabold text-neutral-50 sm:text-5xl sm:tracking-tight lg:text-6xl"
+            class="text-4xl font-extrabold text-neutral-50 sm:text-6xl sm:tracking-tight"
         >
             <slot name="title" />
         </h1>

--- a/src/components/PageTitle.astro
+++ b/src/components/PageTitle.astro
@@ -8,9 +8,9 @@ export interface Props {
 const { as: Component = 'div', ...props } = Astro.props as Props
 ---
 
-<Component class="relative pt-20 pb-12 md:pt-24 md:pb-16 lg:pb-20">
+<Component class="relative py-12 md:py-16 lg:py-20">
     <Starfield subtle />
-    <section class="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8">
+    <section class="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8 flex flex-wrap gap-5 lg:gap-16 justify-between items-center">
         <h1
             class="text-3xl font-extrabold text-neutral-50 sm:text-5xl sm:tracking-tight lg:text-6xl"
         >

--- a/src/components/PageTitle.astro
+++ b/src/components/PageTitle.astro
@@ -16,6 +16,6 @@ const { as: Component = 'div', ...props } = Astro.props as Props
         >
             <slot name="title" />
         </h1>
-        <p class="mt-5 text-lg md:text-xl text-neutral-300"><slot /></p>
+        <div class="text-neutral-300"><slot /></div>
     </section>
 </Component>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -22,7 +22,7 @@ const pathname = Astro.url.pathname.replace(/\/$/, '');
 	<PageTitle as="header">
 		<Fragment slot="title">
 			<span>astro.new</span>{pathname !== '' && (
-				<span class="px-2 font-normal text-secondary-300">/</span>
+				<span class="px-[0.1em] font-normal text-secondary-300">/</span>
 				<span>{pathname.substring(1)}</span>
 			)}
 		</Fragment>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -2,6 +2,7 @@
 import { TOP_SECTION } from '../utils/index'
 import Card from '../components/Card.astro';
 import PageTitle from '../components/PageTitle.astro';
+import Outlinks from '../components/Outlinks.astro';
 
 const { examples: groups } = Astro.props;
 
@@ -41,6 +42,7 @@ const pathname = Astro.url.pathname.replace(/\/$/, '');
 						{category !== TOP_SECTION ? <h2 class="text-2xl">{category}</h2> : null}
 						<ul class="grid sm:grid-cols-2 lg:grid-cols-3 gap-4 lg:gap-6">
 							{examples.map((example) => <li><Card {...example} /></li>)}
+							{category === TOP_SECTION && <Outlinks/>}
 						</ul>
 					</li>
 				);

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -26,6 +26,11 @@ const pathname = Astro.url.pathname.replace(/\/$/, '');
 				<span>{pathname.substring(1)}</span>
 			)}
 		</Fragment>
+		<div class="max-w-prose space-y-4">
+			<p><strong>Welcome to Astro’s official example projects!</strong></p>
+			<p>Each of these templates is meant to show a common pattern or use case: different kinds of websites, various integrations included automatically, or how to work with common tools.</p>
+			<p>Open these in your choice of online code editor right in your browser, or click the GitHub logo to see its source code!</p>
+		</div>
 	</PageTitle>
 
 	<main class="flex flex-col max-w-screen-xl mx-auto pt-8 px-4 sm:px-6 lg:px-8 sm:pt-12 lg:pt-16">


### PR DESCRIPTION
- Add a bit of explainer text to the header to explain what astro.new is!
- Add links to docs & Discord in a helpful bit of empty space in the top section
- Make the kerning around the `/` in `astro.new/next` consistent across font sizes

![Screen Shot 2022-09-03 at 20 02 14](https://user-images.githubusercontent.com/357379/188282905-46658bee-3c0c-4417-85f4-093f99446bdd.png)
