### PR TITLE
rename minimal template to "empty project" to match create-astro wording

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,7 +6,7 @@ const TITLES = new Map([
   ["with-markdown-plugins", "Markdown (Remark Plugins)"],
   ["framework-multiple", "Kitchen Sink (Multiple Frameworks)"],
   ["basics", "Just the Basics"],
-  ["minimal", "Completely Empty"],
+  ["minimal", "Empty Project"],
 ]);
 // this heading is hidden from the page
 export const TOP_SECTION = "TOP_SECTION";


### PR DESCRIPTION
The `create-astro` setup wizard names our minimal template as "Empty project" instead of "Completely Empty." Suggesting a name change here to match, so that it's easy to refer to this template the same way whether created through the wizard or opened here at astro.new