### PR TITLE
Fix heading level flow in document outline

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -13,9 +13,9 @@ import houstonOmg from "../assets/houston_omg.webp"
 			class="flex flex-col gap-4 overflow-hidden rounded-md bg-astro-gray-700 px-6 shadow-md lg:flex-row"
 		>
 			<div class="flex flex-1 flex-col gap-4 py-6 text-astro-gray-200">
-				<p>
+				<h2>
 					Get started with a new Astro project!
-				</p>
+				</h2>
 				<p>
 					Open any of these templates in your choice of online code editor, or view the source code on GitHub.
 				</p>


### PR DESCRIPTION
It’s recommended that page headings increment progressively h1 -> h2 -> h3 etc. for the best accessible document outline experience.

#42 removed the `<h2>` in the hero in favour of a `<p>`, leaving a gap between the page `<h1>` (“It’s go time with Astro”) and the `<h3>` tags heading each of the example cards. I considered the options and reinstated the first line in the hero text (“Get started with a new Astro project!”) as an `<h2>`. The alternative would probably have been to promote the card headings to `<h2>` but I think keeping those nested at `<h3>` so that they are not at the equivalent level of the “Houston, we have resources” heading is best.