### PR TITLE
Add high contrast styles to the tabs

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -217,6 +217,12 @@ const pathname = Astro.url.pathname.replace(/\/$/, "")
 					var(--tw-gradient-stops)
 				);
 			}
+
+			@media (forced-colors: active) {
+				a[data-active] {
+					background-color: Highlight;
+				}
+			}
 		</style>
 
 		<style is:global>


### PR DESCRIPTION
Added a small rule to make the selected tab visible for high-contrast users.

Before:
![image](https://github.com/withastro/astro.new/assets/61414485/29c49b5e-da36-49bf-9d70-667088345cd1)

After:
![image](https://github.com/withastro/astro.new/assets/61414485/68b65dbb-3a66-4a85-99e0-9c24eb41f863)
