### PR TITLE
Updates deprecated Node.js 16 github actions to the latest versions

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -40,4 +40,4 @@ jobs:
         run: pnpm run format
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v5

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -20,15 +20,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
         with:
           version: 8
 
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: pnpm

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,15 +17,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
         with:
           version: 8
 
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: pnpm


### PR DESCRIPTION
Get rid of these:
![image](https://github.com/withastro/astro.new/assets/94928215/83440317-bbc6-4e7e-8154-b6daf4e1b810)
