### PR TITLE
Fix deprecated Netlify adapter import

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,4 +1,4 @@
-import netlify from '@astrojs/netlify/functions';
+import netlify from '@astrojs/netlify';
 import tailwind from '@astrojs/tailwind';
 import { defineConfig } from 'astro/config';
 


### PR DESCRIPTION
Fixes a lint error currently on `main`:

https://github.com/withastro/astro.new/actions/runs/9878913884/job/27283906849