### PR TITLE
Force the `/fonts/` redirect

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,1 @@
-/fonts/*                https://fonts-cdn.astro.build/:splat 200
+/fonts/*                https://fonts-cdn.astro.build/:splat 200!


### PR DESCRIPTION
Not sure if this is the cause of the inconsistencies a few people have seen with font loading, but might be worth a try.

Thinking:

- This project includes a `src/pages/[...rest].astro` route, which _in theory_ could try to handle `/fonts/*`.
- Telling Netlify to force the redirect would _in theory_ avoid that happening.

In practice, this doesn’t seem to be the case (and I can’t see it happening from logs), but if we hear that the problem is persisting this could be worth trying.