### PR TITLE
Fix 1px style bug when hovering “Open in StackBlitz” buttons

### DIFF
--- a/src/components/RepoCard.astro
+++ b/src/components/RepoCard.astro
@@ -31,7 +31,7 @@ const {
 		</p>
 		<hr class="border-astro-gray-500" />
 		<div
-			class="flex h-10 w-max min-w-0 max-w-full gap-px divide-x divide-astro-gray-600 rounded-full bg-blue-purple-gradient"
+			class="flex h-10 w-max min-w-0 max-w-full divide-x divide-astro-gray-600 rounded-full bg-blue-purple-gradient"
 		>
 			<a
 				href={stackblitzUrl}


### PR DESCRIPTION
Fixes the thin vertical line visible when hovering the Open in StackBlitz buttons.

| Before | After |
|------|-------|
| ![open in stack blitz button with one pixel of light colour visible in the hover state that should not be](https://github.com/user-attachments/assets/24bf238a-85d1-4816-81b5-4b1114edd10c) | ![open in stack blitz button with the hovered area fully shaded](https://github.com/user-attachments/assets/24e3b6e2-5e3e-4c4e-a5bc-60c007f105fd) |

