### PR TITLE
Fix unexpected details marker on Safari

### DIFF
--- a/src/components/RepoCard.astro
+++ b/src/components/RepoCard.astro
@@ -135,3 +135,9 @@ const {
 		}
 	}
 </script>
+
+<style>
+	details summary::-webkit-details-marker {
+		display: none;
+	}
+</style>


### PR DESCRIPTION
<img width="413" alt="image" src="https://github.com/user-attachments/assets/ba2a54df-c541-4d7d-9275-1fc0e4f74197">

Removes the unexpected details marker on Safari. `display: flex` seems to remove this on other browsers, but Safari needs an explicit style.