### PR TITLE
Update GitHub workflows to match changes from #74

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: .nvmrc
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: .nvmrc
           cache: pnpm
 
       - name: Install dependencies


### PR DESCRIPTION
Realised I forgot to update the Node and PNPM versions used by the auto-format and lint GitHub workflows leading the auto-format bot to reset the lock file using PNPM v8 in c8907184daff8119089aec725e13970191d22792 for example.

This PR updates those two workflows to use the same Node version as we specify in `.nvmrc` and to let the PNPM setup step infer PNPM version from `package.json`.