### PR TITLE
Embed previews in astro.new

### DIFF
--- a/src/components/GridGradientsAndNoise.astro
+++ b/src/components/GridGradientsAndNoise.astro
@@ -2,10 +2,10 @@
 <div class="noise-underlay bg-grid absolute inset-0 max-h-96 bg-left-top mask-linear-gradient-to-b">
 </div>
 <div
-	class="noise-underlay absolute left-0 top-[28rem] -translate-y-1/2 translate-x-[calc((100vw-1536px)/2)] rounded-full bg-blue-purple-gradient opacity-75 s-[720px] mask-radial-gradient md:-left-48"
+	class="noise-underlay absolute left-0 top-[28rem] -translate-y-1/2 translate-x-[calc((100vw-1536px)/2)] rounded-full bg-gradient-to-br from-astro-purple to-astro-blue opacity-75 s-[800px] mask-radial-gradient lg:-left-48"
 >
 </div>
 <div
-	class="noise-underlay absolute right-0 top-56 -translate-x-[calc((100vw-1536px)/2)] -translate-y-1/2 rounded-full bg-orange-yellow-gradient opacity-60 s-[720px] mask-radial-gradient md:-right-32"
+	class="noise-underlay absolute right-0 top-56 -translate-x-[calc((100vw-1536px)/2)] -translate-y-1/2 rounded-full bg-gradient-to-br from-astro-orange to-astro-yellow opacity-60 s-[800px] mask-radial-gradient lg:-right-32"
 >
 </div>

--- a/src/components/GridGradientsAndNoise.astro
+++ b/src/components/GridGradientsAndNoise.astro
@@ -1,0 +1,11 @@
+<div class="noise"></div>
+<div class="noise-underlay bg-grid absolute inset-0 max-h-96 bg-left-top mask-linear-gradient-to-b">
+</div>
+<div
+	class="noise-underlay absolute left-0 top-[28rem] -translate-y-1/2 translate-x-[calc((100vw-1536px)/2)] rounded-full bg-blue-purple-gradient opacity-75 s-[720px] mask-radial-gradient md:-left-48"
+>
+</div>
+<div
+	class="noise-underlay absolute right-0 top-56 -translate-x-[calc((100vw-1536px)/2)] -translate-y-1/2 rounded-full bg-orange-yellow-gradient opacity-60 s-[720px] mask-radial-gradient md:-right-32"
+>
+</div>

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -1,0 +1,37 @@
+---
+import '@astrojs/site-kit/tailwind.css';
+import '@fontsource-variable/inter';
+import '../styles/fonts.css';
+
+import { ViewTransitions } from 'astro:transitions';
+import { SEO } from '@astrojs/site-kit/components';
+import Inter from '@fontsource-variable/inter/files/inter-latin-wght-normal.woff2';
+import type { ComponentProps } from 'astro/types';
+import houstonOmg from '../assets/houston_omg.webp';
+import Favicon from './Favicon.astro';
+
+type Props = ComponentProps<typeof SEO>;
+
+const { name = 'astro.new', ...props } = Astro.props;
+---
+
+<SEO {name} {...props} />
+
+<link
+	rel="preload"
+	href="/fonts/Obviously/Obviously Normal/Web/Obviously-Regular.woff2"
+	as="font"
+	type="font/woff2"
+	crossorigin
+/>
+<link rel="preload" href={Inter} as="font" type="font/woff2" crossorigin />
+<link rel="preload" href={houstonOmg.src} as="image" type="image/webp" />
+<link rel="preload" href="/assets/noise.webp" as="image" type="image/webp" />
+
+<ViewTransitions />
+
+<Favicon />
+<link rel="mask-icon" href="/favicon.svg" color="#8D46E7" />
+
+<!-- Fathom - beautiful, simple website analytics -->
+<script src="https://cdn.usefathom.com/script.js" data-site="EZBHTSIG" defer></script>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -4,7 +4,9 @@ import AstroLogo from '../components/AstroLogo.astro';
 import { mainSiteLink, socialLinks } from '../data/links';
 ---
 
-<header class="noise-container flex h-24 items-center gap-6 border-b border-astro-gray-100/20 px-8">
+<header
+	class="noise-container z-50 flex h-24 items-center gap-6 border-b border-astro-gray-100/20 px-8"
+>
 	<div class="noise"></div>
 	<a href="/" class="flex items-center gap-6 transition hover:opacity-75" title="Home">
 		<AstroLogo aria-hidden="true" class="h-14 w-10 translate-y-1 object-top" />

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -27,5 +27,5 @@ import { mainSiteLink, socialLinks } from '../data/links';
 			))
 		}
 	</div>
-	<a href={mainSiteLink} class="button button-primary font-medium"> Visit astro.build</a>
+	<a href={mainSiteLink} class="button button-sm button-primary font-medium"> Visit astro.build</a>
 </header>

--- a/src/components/ProjectLauncher.astro
+++ b/src/components/ProjectLauncher.astro
@@ -60,3 +60,9 @@ const { idxUrl, stackblitzUrl, gitpodUrl, codesandboxUrl, menuAlign = 'left' } =
 		</ul>
 	</details>
 </div>
+
+<style>
+	details summary::-webkit-details-marker {
+		display: none;
+	}
+</style>

--- a/src/components/ProjectLauncher.astro
+++ b/src/components/ProjectLauncher.astro
@@ -1,0 +1,62 @@
+---
+import Icon from 'astro-icon';
+import type { Example } from '../data/examples.ts';
+
+type Props = Pick<Example, 'idxUrl' | 'stackblitzUrl' | 'gitpodUrl' | 'codesandboxUrl'> & {
+	menuAlign?: 'left' | 'right';
+};
+
+const { idxUrl, stackblitzUrl, gitpodUrl, codesandboxUrl, menuAlign = 'left' } = Astro.props;
+---
+
+<div
+	class="relative flex h-10 w-max min-w-0 max-w-full divide-x divide-astro-gray-600 rounded-full bg-blue-purple-gradient"
+>
+	<a
+		href={idxUrl}
+		target="_blank"
+		rel="noopener noreferrer"
+		class="flex items-center gap-2 rounded-l-full bg-black/15 px-4 text-sm transition hover:backdrop-brightness-75"
+	>
+		<Icon name="idx" size={16} aria-hidden="true" /> Open in IDX
+	</a>
+	<details class="z-10" data-card-options>
+		<summary
+			class="flex h-full cursor-pointer list-none items-center rounded-r-full bg-black/15 px-2 transition hover:backdrop-brightness-75"
+		>
+			<span class="sr-only">More options</span>
+			<Icon name="chevron-down" size={20} aria-hidden="true" />
+		</summary>
+		<ul
+			class:list={[
+				'absolute top-full mt-2 flex w-max flex-col rounded bg-white p-2 text-astro-gray-700 shadow-md',
+				menuAlign === 'right' ? 'right-0' : 'left-0',
+			]}
+		>
+			<li>
+				<a
+					href={stackblitzUrl}
+					class="flex flex-row items-center gap-2 rounded-sm px-3 py-2 hover:bg-blue-purple-gradient hover:text-white"
+				>
+					<Icon name="stackblitz" size={20} aria-hidden="true" /> Open in StackBlitz
+				</a>
+			</li>
+			<li>
+				<a
+					href={gitpodUrl}
+					class="flex flex-row items-center gap-2 rounded-sm px-3 py-2 hover:bg-blue-purple-gradient hover:text-white"
+				>
+					<Icon name="gitpod" size={20} aria-hidden="true" /> Open in Gitpod
+				</a>
+			</li>
+			<li>
+				<a
+					href={codesandboxUrl}
+					class="flex flex-row items-center gap-2 rounded-sm px-3 py-1.5 hover:bg-blue-purple-gradient hover:text-white"
+				>
+					<Icon name="codesandbox" size={20} aria-hidden="true" /> Open in CodeSandbox
+				</a>
+			</li>
+		</ul>
+	</details>
+</div>

--- a/src/components/RepoCard.astro
+++ b/src/components/RepoCard.astro
@@ -10,12 +10,13 @@ export type Props = Example & { aboveTheFold: boolean };
 
 const {
 	title,
+	name,
 	sourceUrl,
 	idxUrl,
 	stackblitzUrl,
 	codesandboxUrl,
 	gitpodUrl,
-	previewUrl,
+	previewEmbedUrl,
 	createAstroTemplate,
 	loadPreviewImage = () => fallbackImage,
 	aboveTheFold,
@@ -32,20 +33,22 @@ const headingId = `template-${createAstroTemplate}`;
 	<div class="noise z-0"></div>
 	<div class="aspect-video bg-astro-gray-700">
 		<Image
+			transition:name={name}
+			transition:animate="initial"
 			src={image}
 			alt=""
 			loading={aboveTheFold ? 'eager' : 'lazy'}
 			widths={[400, 600, 900]}
 			sizes="(min-width 1280px) 390px,(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
-			class="object-cover object-left-top s-full"
+			class="object-cover object-left-top outline outline-1 -outline-offset-1 outline-astro-gray-100/10 s-full"
 		/>
 	</div>
 	<div class="flex flex-col gap-4 p-5">
 		<h2 class="heading-4" id={headingId}>{title}</h2>
 		<p class="flex flex-wrap gap-2">
 			{
-				previewUrl && (
-					<RepoCardLink as="a" href={previewUrl} icon="eye">
+				previewEmbedUrl && (
+					<RepoCardLink as="a" href={previewEmbedUrl} icon="eye">
 						Preview
 					</RepoCardLink>
 				)

--- a/src/components/RepoCard.astro
+++ b/src/components/RepoCard.astro
@@ -127,9 +127,3 @@ const headingId = `template-${createAstroTemplate}`;
 		}
 	}
 </script>
-
-<style>
-	details summary::-webkit-details-marker {
-		display: none;
-	}
-</style>

--- a/src/components/RepoCard.astro
+++ b/src/components/RepoCard.astro
@@ -48,7 +48,7 @@ const headingId = `template-${createAstroTemplate}`;
 		<p class="flex flex-wrap gap-2">
 			{
 				previewEmbedUrl && (
-					<RepoCardLink as="a" href={previewEmbedUrl} icon="eye">
+					<RepoCardLink as="a" href={previewEmbedUrl} icon="eye" data-astro-prefetch>
 						Preview
 					</RepoCardLink>
 				)

--- a/src/components/RepoCard.astro
+++ b/src/components/RepoCard.astro
@@ -1,9 +1,9 @@
 ---
 import { Image } from 'astro:assets';
-import { Icon } from 'astro-icon';
 import fallbackImage from '../assets/previews/minimal.webp';
 import type { Example } from '../data/examples.js';
 import CopyButton from './CopyButton.astro';
+import ProjectLauncher from './ProjectLauncher.astro';
 import RepoCardLink from './RepoCardLink.astro';
 
 export type Props = Example & { aboveTheFold: boolean };
@@ -54,54 +54,7 @@ const headingId = `template-${createAstroTemplate}`;
 			<CopyButton {createAstroTemplate} />
 		</p>
 		<hr class="border-astro-gray-100/10" />
-		<div
-			class="relative flex h-10 w-max min-w-0 max-w-full divide-x divide-astro-gray-600 rounded-full bg-blue-purple-gradient"
-		>
-			<a
-				href={idxUrl}
-				target="_blank"
-				rel="noopener noreferrer"
-				class="flex items-center gap-2 rounded-l-full bg-black/15 px-4 text-sm transition hover:backdrop-brightness-75"
-			>
-				<Icon name="idx" size={16} aria-hidden="true" /> Open in IDX
-			</a>
-			<details class="z-10" data-card-options>
-				<summary
-					class="flex h-full cursor-pointer list-none items-center rounded-r-full bg-black/15 px-2 transition hover:backdrop-brightness-75"
-				>
-					<span class="sr-only">More options</span>
-					<Icon name="chevron-down" size={20} aria-hidden="true" />
-				</summary>
-				<ul
-					class="absolute left-0 top-full mt-2 flex w-max flex-col rounded bg-white p-2 text-astro-gray-700 shadow-md"
-				>
-					<li>
-						<a
-							href={stackblitzUrl}
-							class="flex flex-row items-center gap-2 rounded-sm px-3 py-2 hover:bg-blue-purple-gradient hover:text-white"
-						>
-							<Icon name="stackblitz" size={20} aria-hidden="true" /> Open in StackBlitz
-						</a>
-					</li>
-					<li>
-						<a
-							href={gitpodUrl}
-							class="flex flex-row items-center gap-2 rounded-sm px-3 py-2 hover:bg-blue-purple-gradient hover:text-white"
-						>
-							<Icon name="gitpod" size={20} aria-hidden="true" /> Open in Gitpod
-						</a>
-					</li>
-					<li>
-						<a
-							href={codesandboxUrl}
-							class="flex flex-row items-center gap-2 rounded-sm px-3 py-1.5 hover:bg-blue-purple-gradient hover:text-white"
-						>
-							<Icon name="codesandbox" size={20} aria-hidden="true" /> Open in CodeSandbox
-						</a>
-					</li>
-				</ul>
-			</details>
-		</div>
+		<ProjectLauncher {...{ idxUrl, stackblitzUrl, codesandboxUrl, gitpodUrl }} />
 	</div>
 </article>
 

--- a/src/icons/arrow-left.svg
+++ b/src/icons/arrow-left.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24"><path fill="currentColor" d="M17 11H9.41l3.3-3.29a1 1 0 1 0-1.42-1.42l-5 5a1 1 0 0 0-.21.33a1 1 0 0 0 0 .76a1 1 0 0 0 .21.33l5 5a1 1 0 0 0 1.42 0a1 1 0 0 0 0-1.42L9.41 13H17a1 1 0 0 0 0-2"/></svg>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,16 +1,8 @@
 ---
-import '@astrojs/site-kit/tailwind.css';
-import '@fontsource-variable/inter';
-import '../styles/fonts.css';
-
-import { ViewTransitions } from 'astro:transitions';
-import { SEO } from '@astrojs/site-kit/components';
-import Inter from '@fontsource-variable/inter/files/inter-latin-wght-normal.woff2';
 import Icon from 'astro-icon';
 import houstonHappy from '../assets/houston_happy.webp';
-import houstonOmg from '../assets/houston_omg.webp';
 import seoBanner from '../assets/seo-banner.webp';
-import Favicon from '../components/Favicon.astro';
+import Head from '../components/Head.astro';
 import Header from '../components/Header.astro';
 import Hero from '../components/Hero.astro';
 import RepoCard from '../components/RepoCard.astro';
@@ -37,30 +29,12 @@ const resolvedSeoBanner = new URL(seoBanner.src, Astro.site).toString();
 
 <html lang="en" class="overflow-x-hidden bg-astro-gray-700 text-astro-gray-100">
 	<head>
-		<SEO
-			name="astro.new"
+		<Head
 			title={exampleGroup.title}
 			description="Quickly launch example Astro projects in your favorite browser IDE!"
 			image={{ src: resolvedSeoBanner, alt: '' }}
 			canonicalURL={new URL(pathname, `https://astro.new`)}
 		/>
-		<ViewTransitions />
-
-		<Favicon />
-		<link rel="mask-icon" href="/favicon.svg" color="#8D46E7" />
-		<link
-			rel="preload"
-			href="/fonts/Obviously/Obviously Normal/Web/Obviously-Regular.woff2"
-			as="font"
-			type="font/woff2"
-			crossorigin
-		/>
-		<link rel="preload" href={Inter} as="font" type="font/woff2" crossorigin />
-		<link rel="preload" href={houstonOmg.src} as="image" type="image/webp" />
-		<link rel="preload" href="/assets/noise.webp" as="image" type="image/webp" />
-
-		<!-- Fathom - beautiful, simple website analytics -->
-		<script src="https://cdn.usefathom.com/script.js" data-site="EZBHTSIG" defer></script>
 	</head>
 
 	<body>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -2,6 +2,7 @@
 import Icon from 'astro-icon';
 import houstonHappy from '../assets/houston_happy.webp';
 import seoBanner from '../assets/seo-banner.webp';
+import GridGradientsAndNoise from '../components/GridGradientsAndNoise.astro';
 import Head from '../components/Head.astro';
 import Header from '../components/Header.astro';
 import Hero from '../components/Hero.astro';
@@ -47,22 +48,10 @@ const resolvedSeoBanner = new URL(seoBanner.src, Astro.site).toString();
 		<Header />
 
 		<div class="noise-container overflow-x-hidden supports-[overflow-x:clip]:overflow-x-clip">
-			<div class="noise"></div>
+			<GridGradientsAndNoise />
 
-			<div class="relative">
-				<div class="noise-underlay bg-grid absolute inset-0 mask-linear-gradient-to-b"></div>
-				<div class="container">
-					<Hero />
-				</div>
-			</div>
-
-			<div
-				class="noise-underlay absolute left-0 top-[350px] h-[600px] w-[calc(max(50vw,300px))] -translate-y-1/2 translate-x-[-60%] rounded-full bg-blue-purple-gradient opacity-75 mask-radial-gradient"
-			>
-			</div>
-			<div
-				class="noise-underlay absolute right-0 top-[350px] h-[600px] w-[calc(max(50vw,300px))] -translate-y-1/2 translate-x-[60%] rounded-full bg-orange-yellow-gradient opacity-75 mask-radial-gradient"
-			>
+			<div class="container">
+				<Hero />
 			</div>
 
 			<main class="container" aria-labelledby="main-heading">

--- a/src/pages/latest/preview/[slug].astro
+++ b/src/pages/latest/preview/[slug].astro
@@ -18,7 +18,7 @@ const { example } = Astro.props;
 const previewImage = await example.loadPreviewImage?.();
 ---
 
-<html lang="en" class="h-full overflow-hidden bg-astro-gray-700 text-astro-gray-100">
+<html lang="en" class="h-dvh overflow-hidden bg-astro-gray-700 text-astro-gray-100">
 	<head>
 		<Head
 			title=`Preview: ${example.title}`

--- a/src/pages/latest/preview/[slug].astro
+++ b/src/pages/latest/preview/[slug].astro
@@ -18,7 +18,7 @@ const { example } = Astro.props;
 const previewImage = await example.loadPreviewImage?.();
 ---
 
-<html lang="en" class="h-full overflow-x-hidden bg-astro-gray-700 text-astro-gray-100">
+<html lang="en" class="h-full overflow-hidden bg-astro-gray-700 text-astro-gray-100">
 	<head>
 		<Head
 			title=`Preview: ${example.title}`
@@ -31,7 +31,7 @@ const previewImage = await example.loadPreviewImage?.();
 
 	<body class="grid h-full grid-rows-[auto,1fr]">
 		<header
-			class="noise-container z-10 grid h-24 grid-cols-[1fr,auto,1fr] items-center gap-6 overflow-x-hidden border-b border-astro-gray-100/20 px-8 supports-[overflow-x:clip]:overflow-x-clip"
+			class="noise-container z-10 grid h-24 grid-cols-[1fr,auto,1fr] items-center gap-6 border-b border-astro-gray-100/20 px-8"
 		>
 			<div class="noise"></div>
 			<a
@@ -52,7 +52,7 @@ const previewImage = await example.loadPreviewImage?.();
 		</header>
 
 		<main
-			class="md:md-y:pb-8 lg:md-y:p-16 noise-container bg-gradient-to-b from-transparent via-transparent to-astro-purple/5 md:p-8 md:pb-0"
+			class="md:md-y:pb-8 lg:md-y:p-16 noise-container overflow-x-hidden bg-gradient-to-b from-transparent via-transparent to-astro-purple/5 supports-[overflow-x:clip]:overflow-x-clip md:p-8 md:pb-0"
 			aria-labelledby="site-preview"
 		>
 			<GridGradientsAndNoise />

--- a/src/pages/latest/preview/[slug].astro
+++ b/src/pages/latest/preview/[slug].astro
@@ -52,7 +52,7 @@ const previewImage = await example.loadPreviewImage?.();
 		</header>
 
 		<main
-			class="md:md-y:pb-8 lg:md-y:p-14 noise-container overflow-x-hidden bg-gradient-to-b from-transparent via-transparent to-astro-purple/5 supports-[overflow-x:clip]:overflow-x-clip md:p-8 md:pb-0"
+			class="noise-container overflow-x-hidden bg-gradient-to-b from-transparent via-transparent to-astro-purple/5 supports-[overflow-x:clip]:overflow-x-clip md:p-8 md:pb-0 md:md-y:pb-8 lg:md-y:p-14"
 			aria-labelledby="site-preview"
 		>
 			<GridGradientsAndNoise />
@@ -62,7 +62,7 @@ const previewImage = await example.loadPreviewImage?.();
 				title=`Preview of ${example.title} template`
 				transition:name={example.name}
 				src={example.previewUrl}
-				class="md:md-y:rounded-3xl md:md-y:border-b-8 mx-auto h-full w-full max-w-screen-2xl border-astro-gray-500/50 bg-white bg-clip-content p-px outline-astro-gray-100/15 ring-inset ring-astro-gray-100/20 md:rounded-t-3xl md:border-8 md:border-b-0 md:shadow-2xl md:outline md:outline-1 md:-outline-offset-1 md:ring-1 md:drop-shadow-md"
+				class="mx-auto h-full w-full max-w-screen-2xl border-astro-gray-500/50 bg-white bg-clip-content outline-astro-gray-100/15 ring-inset ring-astro-gray-100/20 md:rounded-t-3xl md:border-8 md:border-b-0 md:p-px md:pb-0 md:shadow-2xl md:outline md:outline-1 md:-outline-offset-1 md:ring-1 md:drop-shadow-md md:md-y:rounded-3xl md:md-y:border-b-8 md:md-y:p-px"
 			></iframe>
 		</main>
 

--- a/src/pages/latest/preview/[slug].astro
+++ b/src/pages/latest/preview/[slug].astro
@@ -31,8 +31,9 @@ const previewImage = await example.loadPreviewImage?.();
 
 	<body class="grid h-full grid-rows-[auto,1fr]">
 		<header
-			class="noise-container z-10 grid h-24 grid-cols-[1fr,auto,1fr] items-center gap-6 border-b border-astro-gray-100/20 px-8"
+			class="noise-container z-10 grid h-24 grid-cols-[1fr,auto,1fr] items-center gap-6 overflow-x-hidden border-b border-astro-gray-100/20 px-8 supports-[overflow-x:clip]:overflow-x-clip"
 		>
+			<div class="noise"></div>
 			<a href=`/latest/${example.category}/` class="flex items-center gap-4 justify-self-start">
 				<Icon name="arrow-left" size="32" class="s-8" aria-hidden="true" />
 				<span class="sr-only text-sm md:not-sr-only">Back</span>

--- a/src/pages/latest/preview/[slug].astro
+++ b/src/pages/latest/preview/[slug].astro
@@ -34,13 +34,16 @@ const previewImage = await example.loadPreviewImage?.();
 			class="noise-container z-10 grid h-24 grid-cols-[1fr,auto,1fr] items-center gap-6 overflow-x-hidden border-b border-astro-gray-100/20 px-8 supports-[overflow-x:clip]:overflow-x-clip"
 		>
 			<div class="noise"></div>
-			<a href=`/latest/${example.category}/` class="flex items-center gap-4 justify-self-start">
+			<a
+				href=`/latest/${example.category}/`
+				class="link flex items-center gap-4 justify-self-start"
+			>
 				<Icon name="arrow-left" size="32" class="s-8" aria-hidden="true" />
 				<span class="sr-only text-sm md:not-sr-only">Back</span>
 			</a>
 			<h1 class="heading-5 text-center text-base lg:text-xl">{example.title}</h1>
 			<span class="hidden items-center gap-6 justify-self-end md:flex">
-				<a href={example.sourceUrl}>
+				<a href={example.sourceUrl} class="link">
 					<Icon name="github" size="32" class="s-8" aria-hidden="true" />
 					<span class="sr-only">Source code on GitHub</span>
 				</a>

--- a/src/pages/latest/preview/[slug].astro
+++ b/src/pages/latest/preview/[slug].astro
@@ -1,0 +1,85 @@
+---
+import type { GetStaticPaths } from 'astro';
+import Icon from 'astro-icon';
+import GridGradientsAndNoise from '../../../components/GridGradientsAndNoise.astro';
+import Head from '../../../components/Head.astro';
+import ProjectLauncher from '../../../components/ProjectLauncher.astro';
+import { getCategorizedExamples } from '../../../data/examples.ts';
+
+export const getStaticPaths = (async () => {
+	const examples = await getCategorizedExamples();
+	return [...examples.values()]
+		.flatMap((category) => category.items)
+		.filter((example) => example.previewUrl !== null)
+		.map((example) => ({ params: { slug: example.name }, props: { example } }));
+}) satisfies GetStaticPaths;
+
+const { example } = Astro.props;
+const previewImage = await example.loadPreviewImage?.();
+---
+
+<html lang="en" class="h-full overflow-x-hidden bg-astro-gray-700 text-astro-gray-100">
+	<head>
+		<Head
+			title=`Preview: ${example.title}`
+			description=`See a preview of the ${example.title} starter template for Astro.`
+			image={previewImage ? { src: previewImage.src, alt: '' } : undefined}
+			canonicalURL={Astro.url}
+		/>
+		<link rel="preconnect" href="https://preview.astro.new" />
+	</head>
+
+	<body class="grid h-full grid-rows-[auto,1fr]">
+		<header
+			class="noise-container z-10 grid h-24 grid-cols-[1fr,auto,1fr] items-center gap-6 border-b border-astro-gray-100/20 px-8"
+		>
+			<a href=`/latest/${example.category}/` class="flex items-center gap-4 justify-self-start">
+				<Icon name="arrow-left" size="32" class="s-8" aria-hidden="true" />
+				<span class="sr-only text-sm md:not-sr-only">Back</span>
+			</a>
+			<h1 class="heading-5 text-center text-base lg:text-xl">{example.title}</h1>
+			<span class="hidden items-center gap-6 justify-self-end md:flex">
+				<a href={example.sourceUrl}>
+					<Icon name="github" size="32" class="s-8" aria-hidden="true" />
+					<span class="sr-only">Source code on GitHub</span>
+				</a>
+				<ProjectLauncher menuAlign="right" {...example} />
+			</span>
+		</header>
+
+		<main
+			class="md:md-y:pb-8 lg:md-y:p-16 noise-container bg-gradient-to-b from-transparent via-transparent to-astro-purple/5 md:p-8 md:pb-0"
+			aria-labelledby="site-preview"
+		>
+			<GridGradientsAndNoise />
+
+			<iframe
+				id="site-preview"
+				title=`Preview of ${example.title} template`
+				transition:name={example.name}
+				src={example.previewUrl}
+				class="md:md-y:rounded-xl md:md-y:border-b-2 mx-auto h-full w-full max-w-screen-2xl border-astro-gray-500 bg-white bg-clip-content outline-astro-gray-600 ring-astro-gray-100/15 md:rounded-t-xl md:border md:border-b-0 md:shadow-2xl md:outline md:outline-[7px] md:ring-8 md:drop-shadow-md"
+			></iframe>
+		</main>
+
+		<script>
+			// find all internal links, this will pickup all redirects handled by the redirect function
+			document.querySelectorAll<HTMLAnchorElement>("a[href^='/']").forEach((link) => {
+				link.addEventListener('click', () => {
+					window.fathom.trackPageview({
+						url: link.href,
+					});
+				});
+			});
+
+			declare global {
+				// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+				interface Window {
+					fathom: {
+						trackPageview: (options: { url: string }) => void;
+					};
+				}
+			}
+		</script>
+	</body>
+</html>

--- a/src/pages/latest/preview/[slug].astro
+++ b/src/pages/latest/preview/[slug].astro
@@ -52,7 +52,7 @@ const previewImage = await example.loadPreviewImage?.();
 		</header>
 
 		<main
-			class="md:md-y:pb-8 lg:md-y:p-16 noise-container overflow-x-hidden bg-gradient-to-b from-transparent via-transparent to-astro-purple/5 supports-[overflow-x:clip]:overflow-x-clip md:p-8 md:pb-0"
+			class="md:md-y:pb-8 lg:md-y:p-14 noise-container overflow-x-hidden bg-gradient-to-b from-transparent via-transparent to-astro-purple/5 supports-[overflow-x:clip]:overflow-x-clip md:p-8 md:pb-0"
 			aria-labelledby="site-preview"
 		>
 			<GridGradientsAndNoise />
@@ -62,7 +62,7 @@ const previewImage = await example.loadPreviewImage?.();
 				title=`Preview of ${example.title} template`
 				transition:name={example.name}
 				src={example.previewUrl}
-				class="md:md-y:rounded-xl md:md-y:border-b-2 mx-auto h-full w-full max-w-screen-2xl border-astro-gray-500 bg-white bg-clip-content outline-astro-gray-600 ring-astro-gray-100/15 md:rounded-t-xl md:border md:border-b-0 md:shadow-2xl md:outline md:outline-[7px] md:ring-8 md:drop-shadow-md"
+				class="md:md-y:rounded-3xl md:md-y:border-b-8 mx-auto h-full w-full max-w-screen-2xl border-astro-gray-500/50 bg-white bg-clip-content p-px outline-astro-gray-100/15 ring-inset ring-astro-gray-100/20 md:rounded-t-3xl md:border-8 md:border-b-0 md:shadow-2xl md:outline md:outline-1 md:-outline-offset-1 md:ring-1 md:drop-shadow-md"
 			></iframe>
 		</main>
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -16,6 +16,11 @@ export default {
 				secondary: colors.orange,
 				accent: colors.fuchsia,
 			},
+			screens: {
+				'sm-y': { raw: '(min-height: 640px)' },
+				'md-y': { raw: '(min-height: 768px)' },
+				'lg-y': { raw: '(min-height: 1024px)' },
+			},
 		},
 	},
 	plugins: [


### PR DESCRIPTION
This PR enhances the previews added in #81 by adding pages that frame the hosted previews without navigating away from astro.new. That way, clicking through to a preview can show some minimal metadata including our “Open in…” options and it is easy to navigate back to the homepage.

As part of this work I also tweaked the appearance of the background grid and gradients on the homepage subtly so that we could have a nice consistent background across the lists of examples and the preview page.