### PR TITLE
Polish 🧼 

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "@astrojs/check": "^0.9.4",
     "@astrojs/netlify": "^5.5.4",
-    "@fontsource-variable/inter": "^5.1.0",
     "title": "^4.0.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,20 +13,17 @@ importers:
         version: 0.9.4(prettier-plugin-astro@0.14.1)(prettier@3.3.3)(typescript@5.6.3)
       '@astrojs/netlify':
         specifier: ^5.5.4
-        version: 5.5.4(@types/node@20.17.6)(astro@4.16.13)
-      '@fontsource-variable/inter':
-        specifier: ^5.1.0
-        version: 5.1.0
+        version: 5.5.4(@types/node@20.17.6)(astro@4.16.13(@types/node@20.17.6)(rollup@4.27.3)(typescript@5.6.3))
       title:
         specifier: ^4.0.1
         version: 4.0.1
     devDependencies:
       '@astrojs/site-kit':
         specifier: github:withastro/site-kit
-        version: https://codeload.github.com/withastro/site-kit/tar.gz/c53071893428a3069310ae7c79c4485342c364ed(astro@4.16.13)(eslint@8.57.1)(prettier@3.3.3)(tailwindcss@3.4.15)(typescript@5.6.3)
+        version: https://codeload.github.com/withastro/site-kit/tar.gz/c53071893428a3069310ae7c79c4485342c364ed(astro@4.16.13(@types/node@20.17.6)(rollup@4.27.3)(typescript@5.6.3))(eslint@8.57.1)(prettier@3.3.3)(tailwindcss@3.4.15)(typescript@5.6.3)
       '@astrojs/tailwind':
         specifier: ^5.1.2
-        version: 5.1.2(astro@4.16.13)(tailwindcss@3.4.15)
+        version: 5.1.2(astro@4.16.13(@types/node@20.17.6)(rollup@4.27.3)(typescript@5.6.3))(tailwindcss@3.4.15)
       '@biomejs/biome':
         specifier: ^1.9.4
         version: 1.9.4
@@ -41,7 +38,7 @@ importers:
         version: 3.4.3
       astro:
         specifier: ^4.16.13
-        version: 4.16.13(@types/node@20.17.6)(typescript@5.6.3)
+        version: 4.16.13(@types/node@20.17.6)(rollup@4.27.3)(typescript@5.6.3)
       astro-icon:
         specifier: ^0.8.2
         version: 0.8.2
@@ -56,7 +53,7 @@ importers:
         version: 0.14.1
       prettier-plugin-tailwindcss:
         specifier: ^0.6.9
-        version: 0.6.9(prettier-plugin-astro@0.14.1)(prettier@3.3.3)
+        version: 0.6.9(prettier-plugin-astro@0.14.1)(prettier-plugin-jsdoc@1.3.0(prettier@3.3.3))(prettier-plugin-organize-imports@3.2.4(prettier@3.3.3)(typescript@5.6.3))(prettier@3.3.3)
       tailwindcss:
         specifier: ^3.4.15
         version: 3.4.15
@@ -115,7 +112,6 @@ packages:
 
   '@astrojs/site-kit@https://codeload.github.com/withastro/site-kit/tar.gz/c53071893428a3069310ae7c79c4485342c364ed':
     resolution: {tarball: https://codeload.github.com/withastro/site-kit/tar.gz/c53071893428a3069310ae7c79c4485342c364ed}
-    name: '@astrojs/site-kit'
     version: 5.0.0
     peerDependencies:
       astro: '>=2.2.1'
@@ -460,9 +456,6 @@ packages:
   '@eslint/js@8.57.1':
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
-  '@fontsource-variable/inter@5.1.0':
-    resolution: {integrity: sha512-Wj2dUGP0vUpxRGQTXQTCNJO+aLcFcQm+gUPXfj/aS877bQkEPBPv9JvZJpwdm2vzelt8NTZ+ausKlBCJjh2XIg==}
 
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
@@ -3558,8 +3551,6 @@ snapshots:
       '@volar/language-service': 2.4.10
       fast-glob: 3.3.2
       muggle-string: 0.4.1
-      prettier: 3.3.3
-      prettier-plugin-astro: 0.14.1
       volar-service-css: 0.0.62(@volar/language-service@2.4.10)
       volar-service-emmet: 0.0.62(@volar/language-service@2.4.10)
       volar-service-html: 0.0.62(@volar/language-service@2.4.10)
@@ -3569,6 +3560,9 @@ snapshots:
       volar-service-yaml: 0.0.62(@volar/language-service@2.4.10)
       vscode-html-languageservice: 5.3.1
       vscode-uri: 3.0.8
+    optionalDependencies:
+      prettier: 3.3.3
+      prettier-plugin-astro: 0.14.1
     transitivePeerDependencies:
       - typescript
 
@@ -3595,13 +3589,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/netlify@5.5.4(@types/node@20.17.6)(astro@4.16.13)':
+  '@astrojs/netlify@5.5.4(@types/node@20.17.6)(astro@4.16.13(@types/node@20.17.6)(rollup@4.27.3)(typescript@5.6.3))':
     dependencies:
       '@astrojs/internal-helpers': 0.4.1
       '@astrojs/underscore-redirects': 0.3.4
       '@netlify/functions': 2.8.2
       '@vercel/nft': 0.27.6
-      astro: 4.16.13(@types/node@20.17.6)(typescript@5.6.3)
+      astro: 4.16.13(@types/node@20.17.6)(rollup@4.27.3)(typescript@5.6.3)
       esbuild: 0.21.5
       vite: 5.4.11(@types/node@20.17.6)
     transitivePeerDependencies:
@@ -3620,25 +3614,25 @@ snapshots:
     dependencies:
       prismjs: 1.29.0
 
-  '@astrojs/site-kit@https://codeload.github.com/withastro/site-kit/tar.gz/c53071893428a3069310ae7c79c4485342c364ed(astro@4.16.13)(eslint@8.57.1)(prettier@3.3.3)(tailwindcss@3.4.15)(typescript@5.6.3)':
-    id: '@astrojs/site-kit@https://codeload.github.com/withastro/site-kit/tar.gz/c53071893428a3069310ae7c79c4485342c364ed'
+  '@astrojs/site-kit@https://codeload.github.com/withastro/site-kit/tar.gz/c53071893428a3069310ae7c79c4485342c364ed(astro@4.16.13(@types/node@20.17.6)(rollup@4.27.3)(typescript@5.6.3))(eslint@8.57.1)(prettier@3.3.3)(tailwindcss@3.4.15)(typescript@5.6.3)':
     dependencies:
-      '@typescript-eslint/eslint-plugin': 6.21.0(@typescript-eslint/parser@6.21.0)(eslint@8.57.1)(typescript@5.6.3)
+      '@typescript-eslint/eslint-plugin': 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3)
       '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@5.6.3)
-      astro: 4.16.13(@types/node@20.17.6)(typescript@5.6.3)
       eslint: 8.57.1
       eslint-config-prettier: 9.1.0(eslint@8.57.1)
       eslint-plugin-astro: 0.29.1(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
-      eslint-plugin-prettier: 5.2.1(eslint-config-prettier@9.1.0)(eslint@8.57.1)(prettier@3.3.3)
+      eslint-plugin-prettier: 5.2.1(eslint-config-prettier@9.1.0(eslint@8.57.1))(eslint@8.57.1)(prettier@3.3.3)
       prettier: 3.3.3
       prettier-plugin-astro: 0.12.3
       prettier-plugin-jsdoc: 1.3.0(prettier@3.3.3)
       prettier-plugin-organize-imports: 3.2.4(prettier@3.3.3)(typescript@5.6.3)
-      prettier-plugin-tailwindcss: 0.5.14(prettier-plugin-astro@0.12.3)(prettier-plugin-jsdoc@1.3.0)(prettier-plugin-organize-imports@3.2.4)(prettier@3.3.3)
+      prettier-plugin-tailwindcss: 0.5.14(prettier-plugin-astro@0.12.3)(prettier-plugin-jsdoc@1.3.0(prettier@3.3.3))(prettier-plugin-organize-imports@3.2.4(prettier@3.3.3)(typescript@5.6.3))(prettier@3.3.3)
       smartypants: 0.1.6
-      tailwindcss: 3.4.15
       typescript: 5.6.3
+    optionalDependencies:
+      astro: 4.16.13(@types/node@20.17.6)(rollup@4.27.3)(typescript@5.6.3)
+      tailwindcss: 3.4.15
     transitivePeerDependencies:
       - '@ianvs/prettier-plugin-sort-imports'
       - '@prettier/plugin-pug'
@@ -3657,9 +3651,9 @@ snapshots:
       - prettier-plugin-svelte
       - supports-color
 
-  '@astrojs/tailwind@5.1.2(astro@4.16.13)(tailwindcss@3.4.15)':
+  '@astrojs/tailwind@5.1.2(astro@4.16.13(@types/node@20.17.6)(rollup@4.27.3)(typescript@5.6.3))(tailwindcss@3.4.15)':
     dependencies:
-      astro: 4.16.13(@types/node@20.17.6)(typescript@5.6.3)
+      astro: 4.16.13(@types/node@20.17.6)(rollup@4.27.3)(typescript@5.6.3)
       autoprefixer: 10.4.20(postcss@8.4.49)
       postcss: 8.4.49
       postcss-load-config: 4.0.2(postcss@8.4.49)
@@ -3960,8 +3954,6 @@ snapshots:
 
   '@eslint/js@8.57.1': {}
 
-  '@fontsource-variable/inter@5.1.0': {}
-
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
@@ -4125,11 +4117,13 @@ snapshots:
       estree-walker: 2.0.2
       picomatch: 2.3.1
 
-  '@rollup/pluginutils@5.1.3':
+  '@rollup/pluginutils@5.1.3(rollup@4.27.3)':
     dependencies:
       '@types/estree': 1.0.6
       estree-walker: 2.0.2
       picomatch: 4.0.2
+    optionalDependencies:
+      rollup: 4.27.3
 
   '@rollup/rollup-android-arm-eabi@4.27.3':
     optional: true
@@ -4273,7 +4267,7 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0)(eslint@8.57.1)(typescript@5.6.3)':
+  '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
       '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@5.6.3)
@@ -4288,6 +4282,7 @@ snapshots:
       natural-compare: 1.4.0
       semver: 7.6.3
       ts-api-utils: 1.4.0(typescript@5.6.3)
+    optionalDependencies:
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
@@ -4300,6 +4295,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 6.21.0
       debug: 4.3.7
       eslint: 8.57.1
+    optionalDependencies:
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
@@ -4321,6 +4317,7 @@ snapshots:
       debug: 4.3.7
       eslint: 8.57.1
       ts-api-utils: 1.4.0(typescript@5.6.3)
+    optionalDependencies:
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
@@ -4339,6 +4336,7 @@ snapshots:
       minimatch: 9.0.3
       semver: 7.6.3
       ts-api-utils: 1.4.0(typescript@5.6.3)
+    optionalDependencies:
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
@@ -4575,7 +4573,7 @@ snapshots:
       resolve-pkg: 2.0.0
       svgo: 2.8.0
 
-  astro@4.16.13(@types/node@20.17.6)(typescript@5.6.3):
+  astro@4.16.13(@types/node@20.17.6)(rollup@4.27.3)(typescript@5.6.3):
     dependencies:
       '@astrojs/compiler': 2.10.3
       '@astrojs/internal-helpers': 0.4.1
@@ -4585,7 +4583,7 @@ snapshots:
       '@babel/plugin-transform-react-jsx': 7.25.9(@babel/core@7.26.0)
       '@babel/types': 7.26.0
       '@oslojs/encoding': 1.1.0
-      '@rollup/pluginutils': 5.1.3
+      '@rollup/pluginutils': 5.1.3(rollup@4.27.3)
       '@types/babel__core': 7.20.5
       '@types/cookie': 0.6.0
       acorn: 8.14.0
@@ -4632,7 +4630,7 @@ snapshots:
       unist-util-visit: 5.0.0
       vfile: 6.0.3
       vite: 5.4.11(@types/node@20.17.6)
-      vitefu: 1.0.3(vite@5.4.11)
+      vitefu: 1.0.3(vite@5.4.11(@types/node@20.17.6))
       which-pm: 3.0.0
       xxhash-wasm: 1.1.0
       yargs-parser: 21.1.1
@@ -5147,13 +5145,14 @@ snapshots:
       safe-regex-test: 1.0.3
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-prettier@5.2.1(eslint-config-prettier@9.1.0)(eslint@8.57.1)(prettier@3.3.3):
+  eslint-plugin-prettier@5.2.1(eslint-config-prettier@9.1.0(eslint@8.57.1))(eslint@8.57.1)(prettier@3.3.3):
     dependencies:
       eslint: 8.57.1
-      eslint-config-prettier: 9.1.0(eslint@8.57.1)
       prettier: 3.3.3
       prettier-linter-helpers: 1.0.0
       synckit: 0.9.2
+    optionalDependencies:
+      eslint-config-prettier: 9.1.0(eslint@8.57.1)
 
   eslint-scope@7.2.2:
     dependencies:
@@ -6437,8 +6436,9 @@ snapshots:
   postcss-load-config@4.0.2(postcss@8.4.49):
     dependencies:
       lilconfig: 3.1.2
-      postcss: 8.4.49
       yaml: 2.6.1
+    optionalDependencies:
+      postcss: 8.4.49
 
   postcss-nested@6.2.0(postcss@8.4.49):
     dependencies:
@@ -6496,17 +6496,21 @@ snapshots:
       prettier: 3.3.3
       typescript: 5.6.3
 
-  prettier-plugin-tailwindcss@0.5.14(prettier-plugin-astro@0.12.3)(prettier-plugin-jsdoc@1.3.0)(prettier-plugin-organize-imports@3.2.4)(prettier@3.3.3):
+  prettier-plugin-tailwindcss@0.5.14(prettier-plugin-astro@0.12.3)(prettier-plugin-jsdoc@1.3.0(prettier@3.3.3))(prettier-plugin-organize-imports@3.2.4(prettier@3.3.3)(typescript@5.6.3))(prettier@3.3.3):
     dependencies:
       prettier: 3.3.3
+    optionalDependencies:
       prettier-plugin-astro: 0.12.3
       prettier-plugin-jsdoc: 1.3.0(prettier@3.3.3)
       prettier-plugin-organize-imports: 3.2.4(prettier@3.3.3)(typescript@5.6.3)
 
-  prettier-plugin-tailwindcss@0.6.9(prettier-plugin-astro@0.14.1)(prettier@3.3.3):
+  prettier-plugin-tailwindcss@0.6.9(prettier-plugin-astro@0.14.1)(prettier-plugin-jsdoc@1.3.0(prettier@3.3.3))(prettier-plugin-organize-imports@3.2.4(prettier@3.3.3)(typescript@5.6.3))(prettier@3.3.3):
     dependencies:
       prettier: 3.3.3
+    optionalDependencies:
       prettier-plugin-astro: 0.14.1
+      prettier-plugin-jsdoc: 1.3.0(prettier@3.3.3)
+      prettier-plugin-organize-imports: 3.2.4(prettier@3.3.3)(typescript@5.6.3)
 
   prettier@2.8.7:
     optional: true
@@ -7052,7 +7056,7 @@ snapshots:
   ts-interface-checker@0.1.13: {}
 
   tsconfck@3.1.4(typescript@5.6.3):
-    dependencies:
+    optionalDependencies:
       typescript: 5.6.3
 
   tslib@2.8.1: {}
@@ -7202,65 +7206,72 @@ snapshots:
 
   vite@5.4.11(@types/node@20.17.6):
     dependencies:
-      '@types/node': 20.17.6
       esbuild: 0.21.5
       postcss: 8.4.49
       rollup: 4.27.3
     optionalDependencies:
+      '@types/node': 20.17.6
       fsevents: 2.3.3
 
-  vitefu@1.0.3(vite@5.4.11):
-    dependencies:
+  vitefu@1.0.3(vite@5.4.11(@types/node@20.17.6)):
+    optionalDependencies:
       vite: 5.4.11(@types/node@20.17.6)
 
   volar-service-css@0.0.62(@volar/language-service@2.4.10):
     dependencies:
-      '@volar/language-service': 2.4.10
       vscode-css-languageservice: 6.3.1
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.0.8
+    optionalDependencies:
+      '@volar/language-service': 2.4.10
 
   volar-service-emmet@0.0.62(@volar/language-service@2.4.10):
     dependencies:
       '@emmetio/css-parser': 0.4.0
       '@emmetio/html-matcher': 1.3.0
-      '@volar/language-service': 2.4.10
       '@vscode/emmet-helper': 2.11.0
       vscode-uri: 3.0.8
+    optionalDependencies:
+      '@volar/language-service': 2.4.10
 
   volar-service-html@0.0.62(@volar/language-service@2.4.10):
     dependencies:
-      '@volar/language-service': 2.4.10
       vscode-html-languageservice: 5.3.1
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.0.8
+    optionalDependencies:
+      '@volar/language-service': 2.4.10
 
   volar-service-prettier@0.0.62(@volar/language-service@2.4.10)(prettier@3.3.3):
     dependencies:
+      vscode-uri: 3.0.8
+    optionalDependencies:
       '@volar/language-service': 2.4.10
       prettier: 3.3.3
-      vscode-uri: 3.0.8
 
   volar-service-typescript-twoslash-queries@0.0.62(@volar/language-service@2.4.10):
     dependencies:
-      '@volar/language-service': 2.4.10
       vscode-uri: 3.0.8
+    optionalDependencies:
+      '@volar/language-service': 2.4.10
 
   volar-service-typescript@0.0.62(@volar/language-service@2.4.10):
     dependencies:
-      '@volar/language-service': 2.4.10
       path-browserify: 1.0.1
       semver: 7.6.3
       typescript-auto-import-cache: 0.3.5
       vscode-languageserver-textdocument: 1.0.12
       vscode-nls: 5.2.0
       vscode-uri: 3.0.8
+    optionalDependencies:
+      '@volar/language-service': 2.4.10
 
   volar-service-yaml@0.0.62(@volar/language-service@2.4.10):
     dependencies:
-      '@volar/language-service': 2.4.10
       vscode-uri: 3.0.8
       yaml-language-server: 1.15.0
+    optionalDependencies:
+      '@volar/language-service': 2.4.10
 
   vscode-css-languageservice@6.3.1:
     dependencies:

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -5,7 +5,6 @@ import '../styles/fonts.css';
 
 import { ViewTransitions } from 'astro:transitions';
 import { SEO } from '@astrojs/site-kit/components';
-import Inter from '@fontsource-variable/inter/files/inter-latin-wght-normal.woff2';
 import type { ComponentProps } from 'astro/types';
 import houstonOmg from '../assets/houston_omg.webp';
 import Favicon from './Favicon.astro';
@@ -24,7 +23,6 @@ const { name = 'astro.new', ...props } = Astro.props;
 	type="font/woff2"
 	crossorigin
 />
-<link rel="preload" href={Inter} as="font" type="font/woff2" crossorigin />
 <link rel="preload" href={houstonOmg.src} as="image" type="image/webp" />
 <link rel="preload" href="/assets/noise.webp" as="image" type="image/webp" />
 

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -1,6 +1,5 @@
 ---
 import '@astrojs/site-kit/tailwind.css';
-import '@fontsource-variable/inter';
 import '../styles/fonts.css';
 
 import { ViewTransitions } from 'astro:transitions';

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -3,15 +3,18 @@ import houstonOmg from '../assets/houston_omg.webp';
 ---
 
 <section class="flex flex-col items-center gap-16 py-16 lg:flex-row" aria-labelledby="hero-heading">
-	<h2 class="heading-2 text-center text-5xl/tight sm:text-6xl/tight lg:text-left" id="hero-heading">
+	<h2
+		class="heading-2 text-pretty text-center text-5xl/tight sm:text-6xl/tight lg:max-w-lg lg:text-left"
+		id="hero-heading"
+	>
 		It’s go time with Astro
 	</h2>
-	<div class="rounded-md bg-blue-purple-gradient p-px">
+	<div class="w-[640px] max-w-full rounded-md bg-blue-purple-gradient p-px shadow-md @container">
 		<section
-			class="flex flex-col gap-4 overflow-hidden rounded-md bg-astro-gray-700 px-6 shadow-md lg:flex-row"
+			class="flex flex-col overflow-hidden rounded-md bg-astro-gray-700 px-6 @sm:flex-row @sm:gap-6"
 		>
 			<div class="flex flex-1 flex-col gap-4 py-6 text-astro-gray-200">
-				<h3>Get started with a new Astro project!</h3>
+				<h3 class="font-medium text-white">Get started with a new Astro project!</h3>
 				<p>
 					Open any of these templates in your choice of online code editor, or view the source code
 					on GitHub.
@@ -20,7 +23,7 @@ import houstonOmg from '../assets/houston_omg.webp';
 			<img
 				src={houstonOmg.src}
 				alt="Astro's mascot, Houston, making an 'omg' face"
-				class="-mb-1 self-center lg:self-end"
+				class="-mb-px h-8 w-auto self-center @sm:self-end @md:-mb-1 @md:h-16 @lg:h-24"
 				width="156"
 				height="104"
 			/>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -55,7 +55,7 @@ const resolvedSeoBanner = new URL(seoBanner.src, Astro.site).toString();
 			</div>
 
 			<main class="container" aria-labelledby="main-heading">
-				<nav class="flex flex-wrap border-b border-astro-gray-100/20">
+				<nav class="flex overflow-auto whitespace-nowrap border-b border-astro-gray-100/20">
 					{
 						[...Astro.props.examples.values()].map((group) => (
 							<a

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -3,6 +3,7 @@ import preset from '@astrojs/site-kit/tailwind-preset';
 import containerQueries from '@tailwindcss/container-queries';
 import type { Config } from 'tailwindcss';
 import colors from 'tailwindcss/colors.js';
+import { fontFamily } from 'tailwindcss/defaultTheme.js';
 import plugin from 'tailwindcss/plugin.js';
 
 export default {
@@ -10,6 +11,9 @@ export default {
 	content: ['./src/**/*.{astro,js,ts,jsx,tsx}'],
 	theme: {
 		extend: {
+			fontFamily: {
+				sans: fontFamily.sans,
+			},
 			colors: {
 				neutral: colors.slate,
 				primary: colors.purple,


### PR DESCRIPTION
Small bits of UI polish

- The tab-like navigation links between categories no longer wrap on small screens, but overflow instead, avoiding the somewhat odd behaviour in relationship to their bottom border. There’s no change on larger screen sizes.

   | Before | After |
   |---|---|
   | ![stacked links](https://github.com/user-attachments/assets/c4dc84ae-ee9d-427b-8b5d-0edae9be19eb) | ![Links laid out in a row](https://github.com/user-attachments/assets/9ddc827f-a1e5-4a70-a012-71000689fade) |

- Fixed sans-serif font configuration and removed Inter font files & CSS. I realised while working on this that no parts of the UI were actually _using_ Inter. The Tailwind configuration we had was set to use `InterVariable, sans-serif`, but we were loading `Inter` (not variable, just the regular weight). So regular Inter was loaded, but never used, falling back to the default sans-serif. Instead of fixing this to introduce Inter somewhere, I reckon we can get away without it, so this PR also removes it from loading. No visual impact, but saves a pointless download.

- Reworks the hero layout to make better use of available space at different screen sizes and tweak a few minor details.

   ### Before
   
   https://github.com/user-attachments/assets/bd9073b5-781a-4516-a18c-50c48ed63e5d
   
   ### After
   
   https://github.com/user-attachments/assets/8f165142-0304-4e10-838d-8d6a9f740b1c

