### PR TITLE
Update Node & nixpkgs in Firebase Studio templates

### DIFF
--- a/.idx-templates/latest/dev.nix
+++ b/.idx-templates/latest/dev.nix
@@ -4,7 +4,7 @@
   # Which nixpkgs channel to use.
   channel = "stable-24.05"; # or "unstable"
   # Use https://search.nixos.org/packages to find packages
-  packages = [ pkgs.nodejs_20 ];
+  packages = [ pkgs.nodejs_24 ];
   # Sets environment variables in the workspace
   env = { };
   idx = let

--- a/.idx-templates/latest/dev.nix
+++ b/.idx-templates/latest/dev.nix
@@ -4,7 +4,7 @@
   # Which nixpkgs channel to use.
   channel = "stable-25.11"; # or "unstable"
   # Use https://search.nixos.org/packages to find packages
-  packages = [ pkgs.nodejs_24 ];
+  packages = [ pkgs.nodejs_22 ];
   # Sets environment variables in the workspace
   env = { };
   idx = let

--- a/.idx-templates/latest/dev.nix
+++ b/.idx-templates/latest/dev.nix
@@ -2,7 +2,7 @@
 # see: https://firebase.google.com/docs/studio/devnix-reference
 { pkgs, ... }: {
   # Which nixpkgs channel to use.
-  channel = "stable-25.11"; # or "unstable"
+  channel = "stable-25.05"; # or "unstable"
   # Use https://search.nixos.org/packages to find packages
   packages = [ pkgs.nodejs_22 ];
   # Sets environment variables in the workspace

--- a/.idx-templates/latest/dev.nix
+++ b/.idx-templates/latest/dev.nix
@@ -2,7 +2,7 @@
 # see: https://firebase.google.com/docs/studio/devnix-reference
 { pkgs, ... }: {
   # Which nixpkgs channel to use.
-  channel = "stable-24.05"; # or "unstable"
+  channel = "stable-25.11"; # or "unstable"
   # Use https://search.nixos.org/packages to find packages
   packages = [ pkgs.nodejs_24 ];
   # Sets environment variables in the workspace

--- a/.idx-templates/latest/idx-template.nix
+++ b/.idx-templates/latest/idx-template.nix
@@ -1,5 +1,5 @@
 { pkgs, astroTemplate ? "basics", debug ? false, ... }: {
-  packages = [ pkgs.git pkgs.nodejs_24 pkgs.nodePackages.pnpm ];
+  packages = [ pkgs.git pkgs.nodejs_22 pkgs.nodePackages.pnpm ];
 
   bootstrap = let
     script = pkgs.writeShellScript "bootstrap" ''

--- a/.idx-templates/latest/idx-template.nix
+++ b/.idx-templates/latest/idx-template.nix
@@ -1,5 +1,5 @@
 { pkgs, astroTemplate ? "basics", debug ? false, ... }: {
-  packages = [ pkgs.git pkgs.nodejs_20 pkgs.nodePackages.pnpm ];
+  packages = [ pkgs.git pkgs.nodejs_24 pkgs.nodePackages.pnpm ];
 
   bootstrap = let
     script = pkgs.writeShellScript "bootstrap" ''

--- a/.idx-templates/next/dev.nix
+++ b/.idx-templates/next/dev.nix
@@ -4,7 +4,7 @@
   # Which nixpkgs channel to use.
   channel = "stable-24.05"; # or "unstable"
   # Use https://search.nixos.org/packages to find packages
-  packages = [ pkgs.nodejs_20 ];
+  packages = [ pkgs.nodejs_24 ];
   # Sets environment variables in the workspace
   env = { };
   idx = let

--- a/.idx-templates/next/dev.nix
+++ b/.idx-templates/next/dev.nix
@@ -4,7 +4,7 @@
   # Which nixpkgs channel to use.
   channel = "stable-25.11"; # or "unstable"
   # Use https://search.nixos.org/packages to find packages
-  packages = [ pkgs.nodejs_24 ];
+  packages = [ pkgs.nodejs_22 ];
   # Sets environment variables in the workspace
   env = { };
   idx = let

--- a/.idx-templates/next/dev.nix
+++ b/.idx-templates/next/dev.nix
@@ -2,7 +2,7 @@
 # see: https://firebase.google.com/docs/studio/devnix-reference
 { pkgs, ... }: {
   # Which nixpkgs channel to use.
-  channel = "stable-25.11"; # or "unstable"
+  channel = "stable-25.05"; # or "unstable"
   # Use https://search.nixos.org/packages to find packages
   packages = [ pkgs.nodejs_22 ];
   # Sets environment variables in the workspace

--- a/.idx-templates/next/dev.nix
+++ b/.idx-templates/next/dev.nix
@@ -2,7 +2,7 @@
 # see: https://firebase.google.com/docs/studio/devnix-reference
 { pkgs, ... }: {
   # Which nixpkgs channel to use.
-  channel = "stable-24.05"; # or "unstable"
+  channel = "stable-25.11"; # or "unstable"
   # Use https://search.nixos.org/packages to find packages
   packages = [ pkgs.nodejs_24 ];
   # Sets environment variables in the workspace

--- a/.idx-templates/next/idx-template.nix
+++ b/.idx-templates/next/idx-template.nix
@@ -1,5 +1,5 @@
 { pkgs, astroTemplate ? "basics", debug ? false, ... }: {
-  packages = [ pkgs.git pkgs.nodejs_24 pkgs.nodePackages.pnpm ];
+  packages = [ pkgs.git pkgs.nodejs_22 pkgs.nodePackages.pnpm ];
 
   bootstrap = let
     script = pkgs.writeShellScript "bootstrap" ''

--- a/.idx-templates/next/idx-template.nix
+++ b/.idx-templates/next/idx-template.nix
@@ -1,5 +1,5 @@
 { pkgs, astroTemplate ? "basics", debug ? false, ... }: {
-  packages = [ pkgs.git pkgs.nodejs_20 pkgs.nodePackages.pnpm ];
+  packages = [ pkgs.git pkgs.nodejs_24 pkgs.nodePackages.pnpm ];
 
   bootstrap = let
     script = pkgs.writeShellScript "bootstrap" ''


### PR DESCRIPTION
- Closes #94 
- Updates Node 20 => ~~24~~ 22 for Astro 6 support (I initially tried 24 but it said it couldn’t find a `nodejs_24` package 🤷)
- Also updates the nixpkgs channel while there

To test I used https://studio.firebase.google.com/new?utm_source=astro&utm_medium=astro&utm_campaign=astro&astroTemplate=minimal&name=Empty%20Project&template=https:%2F%2Fgithub.com%2Fwithastro%2Fastro.new%2Ftree%2Ftest%2F.idx-templates%2Flatest to create a new environment with these changes (this is on the `test` branch which mirrors this one because it turns out Firebase Studio can’t handle branch names containing `/`)